### PR TITLE
Fixes TP 1704

### DIFF
--- a/onadata/apps/viewer/static/js/stats_tables.js
+++ b/onadata/apps/viewer/static/js/stats_tables.js
@@ -278,7 +278,7 @@
             });
 
             // determine column type based on field type
-            var columnDef = {name: field.get('name'), label: "Answers", editable: false, cell: "string"}
+            var columnDef = {name: field.get('xpath'), label: "Answers", editable: false, cell: "string"}
             if(field.isA(FH.types.INTEGER || field.isA(FH.types.DECIMAL))) {
                 columnDef.sortValue = function(model, fieldId) {
                     var func = FH.ParseFunctionMapping[field.get(FH.constants.TYPE)];


### PR DESCRIPTION
The data returned by the API (e.g. /api/v1/stats/submissions/8850?group=intro/Interviewer_s_name) looks like `[{"count": 1, "intro/Interviewer_s_name": "Lawrence "}]`, reflecting that `Interviewer_s_name` is within the group `intro`. The identifiers with slashes are [created by `XFormInstanceParser`](https://github.com/kobotoolbox/kobocat/blob/eeeeb870acffe6f74902d0b5a5319d55b683ef17/onadata/apps/logger/xform_instance_parser.py#L287).

Likewise, the client [parses form.json and sets and `xpath` attribute for each question](https://github.com/kobotoolbox/kobocat/blob/eeeeb870acffe6f74902d0b5a5319d55b683ef17/onadata/apps/viewer/static/js/xform.js#L184). However, the "Analyze data" table-creation code tell Backgrid.js that it should [simply use the `name` attribute](https://github.com/kobotoolbox/kobocat/blob/eeeeb870acffe6f74902d0b5a5319d55b683ef17/onadata/apps/viewer/static/js/stats_tables.js#L281) of each question as the key for values in the first column, causing that column to remain empty whenever the question has any parent (e.g. a group).