### PR TITLE
Make API authentication more consistent

### DIFF
--- a/onadata/apps/api/viewsets/briefcase_api.py
+++ b/onadata/apps/api/viewsets/briefcase_api.py
@@ -79,7 +79,6 @@ class BriefcaseApi(OpenRosaHeadersMixin, mixins.CreateModelMixin,
     Implements the [Briefcase Aggregate API](\
     https://code.google.com/p/opendatakit/wiki/BriefcaseAggregateAPI).
     """
-    authentication_classes = (DigestAuthentication,)
     filter_backends = (filters.AnonDjangoObjectPermissionFilter,)
     queryset = XForm.objects.all()
     permission_classes = (permissions.IsAuthenticated,
@@ -87,6 +86,18 @@ class BriefcaseApi(OpenRosaHeadersMixin, mixins.CreateModelMixin,
     renderer_classes = (TemplateXMLRenderer, BrowsableAPIRenderer)
     serializer_class = XFormListSerializer
     template_name = 'openrosa_response.xml'
+
+    def __init__(self, *args, **kwargs):
+        super(BriefcaseApi, self).__init__(*args, **kwargs)
+        # Respect DEFAULT_AUTHENTICATION_CLASSES, but also ensure that the
+        # previously hard-coded authentication classes are included first
+        authentication_classes = [
+            DigestAuthentication,
+        ]
+        self.authentication_classes = authentication_classes + [
+            auth_class for auth_class in self.authentication_classes
+                if not auth_class in authentication_classes
+        ]
 
     def get_object(self, queryset=None):
         formId = self.request.GET.get('formId', '')

--- a/onadata/apps/api/viewsets/xform_list_api.py
+++ b/onadata/apps/api/viewsets/xform_list_api.py
@@ -29,7 +29,6 @@ DEFAULT_CONTENT_LENGTH = getattr(settings, 'DEFAULT_CONTENT_LENGTH', 10000000)
 
 
 class XFormListApi(viewsets.ReadOnlyModelViewSet):
-    authentication_classes = (DigestAuthentication,)
     content_negotiation_class = MediaFileContentNegotiation
     filter_backends = (filters.XFormListObjectPermissionFilter,)
     queryset = XForm.objects.filter(downloadable=True)
@@ -37,6 +36,18 @@ class XFormListApi(viewsets.ReadOnlyModelViewSet):
     renderer_classes = (XFormListRenderer,)
     serializer_class = XFormListSerializer
     template_name = 'api/xformsList.xml'
+
+    def __init__(self, *args, **kwargs):
+        super(XFormListApi, self).__init__(*args, **kwargs)
+        # Respect DEFAULT_AUTHENTICATION_CLASSES, but also ensure that the
+        # previously hard-coded authentication classes are included first
+        authentication_classes = [
+            DigestAuthentication,
+        ]
+        self.authentication_classes = authentication_classes + [
+            auth_class for auth_class in self.authentication_classes
+                if not auth_class in authentication_classes
+        ]
 
     def get_openrosa_headers(self):
         tz = pytz.timezone(settings.TIME_ZONE)

--- a/onadata/apps/api/viewsets/xform_submission_api.py
+++ b/onadata/apps/api/viewsets/xform_submission_api.py
@@ -128,9 +128,6 @@ Here is some example JSON, it would replace `[the JSON]` above:
 >           }
 >       }
 """
-    authentication_classes = (DigestAuthentication,
-                              BasicAuthentication,
-                              TokenAuthentication)
     filter_backends = (filters.AnonDjangoObjectPermissionFilter,)
     model = Instance
     permission_classes = (permissions.AllowAny,)
@@ -139,6 +136,25 @@ Here is some example JSON, it would replace `[the JSON]` above:
                         BrowsableAPIRenderer)
     serializer_class = SubmissionSerializer
     template_name = 'submission.xml'
+
+    def __init__(self, *args, **kwargs):
+        super(XFormSubmissionApi, self).__init__(*args, **kwargs)
+        # Respect DEFAULT_AUTHENTICATION_CLASSES, but also ensure that the
+        # previously hard-coded authentication classes are included first
+        authentication_classes = [
+            DigestAuthentication,
+            BasicAuthentication,
+            TokenAuthentication
+        ]
+        # We include BasicAuthentication here to allow submissions using basic
+        # authentication over unencrypted HTTP. REST framework stops after the
+        # first class that successfully authenticates, so
+        # HttpsOnlyBasicAuthentication will be ignored even if included by
+        # DEFAULT_AUTHENTICATION_CLASSES.
+        self.authentication_classes = authentication_classes + [
+            auth_class for auth_class in self.authentication_classes
+                if not auth_class in authentication_classes
+        ]
 
     def create(self, request, *args, **kwargs):
         username = self.kwargs.get('username')

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -1,7 +1,8 @@
 from django.utils.translation import ugettext as _
 from django_digest import HttpDigestAuthenticator
 from rest_framework.authentication import (
-    BaseAuthentication, get_authorization_header)
+    BaseAuthentication, get_authorization_header,
+    BasicAuthentication)
 from rest_framework.exceptions import AuthenticationFailed
 
 
@@ -25,3 +26,13 @@ class DigestAuthentication(BaseAuthentication):
         response = self.authenticator.build_challenge_response()
 
         return response['WWW-Authenticate']
+
+class HttpsOnlyBasicAuthentication(BasicAuthentication):
+    def authenticate(self, request):
+        if not request.is_secure():
+            raise AuthenticationFailed(_(
+                u'Using basic authentication without HTTPS transmits '
+                u'credentials in clear text! You MUST connect via HTTPS '
+                u'to use basic authentication.'
+            ))
+        return super(HttpsOnlyBasicAuthentication, self).authenticate(request)

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -250,6 +250,7 @@ REST_FRAMEWORK = {
         'oauth2_provider.ext.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
+        'onadata.libs.authentication.HttpsOnlyBasicAuthentication',
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.UnicodeJSONRenderer',


### PR DESCRIPTION
Now allows basic authentication over HTTPS by default. Unencrypted basic authentication is prohibited for everything except XForm submission.