### PR TITLE
Serve static and media files with Django's static files views ONLY in debug mode

### DIFF
--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -267,10 +267,12 @@ urlpatterns = patterns(
         'onadata.apps.logger.views.ziggy_submissions'),
 
     # static media
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
-        {'document_root': settings.MEDIA_ROOT}),
     url(r'^favicon\.ico',
         RedirectView.as_view(url='/static/images/favicon.ico')))
 
-urlpatterns += patterns('django.contrib.staticfiles.views',
-                        url(r'^static/(?P<path>.*)$', 'serve'))
+if settings.DEBUG:
+  urlpatterns += patterns('', url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': settings.MEDIA_ROOT}))
+  urlpatterns += patterns('django.contrib.staticfiles.views',
+                          url(r'^static/(?P<path>.*)$', 'serve'))
+


### PR DESCRIPTION
I _think_ this fixes an error in DEBUG=False mode that reads like "ImproperlyConfigured: The staticfiles view can only be used in debug mode or if the --insecure option of 'runserver' is used."

Even if this is not fixing that, this is adhering to docs which have the user use these views only in DEBUG=True mode:
https://docs.djangoproject.com/en/1.8/ref/contrib/staticfiles/#static-file-development-view
(relevant part is `if settings.DEBUG:` in the example code.)
