### PR TITLE
adding ALLOWED_HOSTS to kc_environ

### DIFF
--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -29,6 +29,8 @@ try:
 except KeyError:
     raise Exception('DJANGO_SECRET_KEY must be set in the environment.')
 
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '*').split(' ')
+
 TESTING_MODE = False
 # This trick works only when we run tests from the command line.
 if len(sys.argv) >= 2 and (sys.argv[1] == "test"):


### PR DESCRIPTION
DJANGO_ALLOWED_HOSTS environment variable is a space-separated list
which is pulled into settings.

https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts