### PR TITLE
Forms API redeployment enhancements

### DIFF
--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -760,8 +760,13 @@ data (instance/submission per row)
         if 'xls_file' in request.FILES or 'text_xls_form' in request.data:
             # A new XLSForm has been uploaded and will replace the existing
             # form
-            owner = _get_owner(request)
             existing_xform = get_object_or_404(XForm, pk=pk)
+            # Behave like `onadata.apps.main.views.update_xform`: only allow
+            # the update to proceed if the user is the owner
+            owner = existing_xform.user
+            if request.user.pk != owner.pk:
+                raise exceptions.PermissionDenied(
+                    detail=_("Only a form's owner can overwrite its contents"))
             survey = utils.publish_xlsform(request, owner, existing_xform)
             if not isinstance(survey, XForm):
                 if isinstance(survey, dict) and 'text' in survey:

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -402,8 +402,10 @@ https://example.com/api/v1/forms/28058
 
 ## Update Form
 
-You can overwrite the form while maintaining the same `id_string` and other
-elements by sending a `PATCH` with the `xls_file` parameter.
+You may overwrite the form's contents while preserving its submitted data,
+`id_string` and all other attributes, by sending a `PATCH` that includes
+`xls_file` or `text_xls_form`. Use with caution, as this may compromise the
+methodology of your study!
 
 <pre class="prettyprint">
 <b>PATCH</b> /api/v1/forms/<code>{pk}</code></pre>
@@ -742,7 +744,7 @@ data (instance/submission per row)
         return Response(survey, status=status.HTTP_400_BAD_REQUEST)
 
     def update(self, request, pk, *args, **kwargs):
-        if 'xls_file' in request.FILES:
+        if 'xls_file' in request.FILES or 'text_xls_form' in request.data:
             # A new XLSForm has been uploaded and will replace the existing
             # form
             owner = _get_owner(request)

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -54,6 +54,14 @@ class XFormOwnerFilter(filters.BaseFilterBackend):
         return queryset
 
 
+class XFormIdStringFilter(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        id_string = request.query_params.get('id_string')
+        if id_string:
+            return queryset.filter(id_string=id_string)
+        return queryset
+
+
 class ProjectOwnerFilter(XFormOwnerFilter):
     owner_prefix = 'organization'
 

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -32,7 +32,7 @@ class XFormSerializer(serializers.HyperlinkedModelSerializer):
     # but now it must be implemented manually
     def validate(self, attrs):
         shared = attrs.get('shared')
-        if shared not in ('True', 'False'):
+        if shared is not None and shared not in ('True', 'False'):
             msg = "'%s' value must be either True or False." % shared
             raise serializers.ValidationError({'shared': msg})
         attrs['shared'] = shared == 'True'

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -32,7 +32,7 @@ class XFormSerializer(serializers.HyperlinkedModelSerializer):
     # but now it must be implemented manually
     def validate(self, attrs):
         shared = attrs.get('shared')
-        if shared is not None and shared not in ('True', 'False'):
+        if shared not in (None, 'True', 'False'):
             msg = "'%s' value must be either True or False." % shared
             raise serializers.ValidationError({'shared': msg})
         attrs['shared'] = shared == 'True'


### PR DESCRIPTION
Allow filtering forms by `id_string`; allow `PATCH`ing to update form contents via `text_xls_form` or `xls_file` in the request
Closes #138 
Supersedes #154 