### PR TITLE
Header fix

### DIFF
--- a/onadata/apps/survey_report/templates/survey_report/auto_report.html
+++ b/onadata/apps/survey_report/templates/survey_report/auto_report.html
@@ -2,6 +2,18 @@
 {% load i18n %}
 {% load data_manipulation %}
 
+<div class="sub-header-bar">
+  <div class="container__wide">
+    <a class="sub-header__back" href="{% url "onadata.apps.main.views.show" xform.user.username xform.id_string %}"><i class="fa fa-chevron-left"></i> {% trans "Return to" %} {{ xform.title }}</a>
+  </div>
+</div>
+
+<header class="data-page__header">
+    <hgroup class="container">
+      <h1>{% trans "Report" %}</h1>
+    </hgroup>
+</header>
+
 {% block content %}
 
 <style type="text/css" media="screen">
@@ -119,18 +131,6 @@ label, button {
 }
 
 </style>
-
-<div class="sub-header-bar">
-  <div class="container__wide">
-    <a class="sub-header__back" href="{% url "onadata.apps.main.views.show" xform.user.username xform.id_string %}"><i class="fa fa-chevron-left"></i> {% trans "Return to" %} {{ xform.title }}</a>
-  </div>
-</div>
-
-<header class="data-page__header">
-    <hgroup class="container">
-      <h1>{% trans "Automatic report" %}</h1>
-    </hgroup>
-</header>
 
 <form action="{% url 'formpack_auto_report' username id_string %}"
       method="get" accept-charset="utf-8">

--- a/onadata/apps/survey_report/templates/survey_report/export_menu.html
+++ b/onadata/apps/survey_report/templates/survey_report/export_menu.html
@@ -1,6 +1,17 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
+<div class="sub-header-bar">
+  <div class="container__wide">
+    <a class="sub-header__back" href="{% url "onadata.apps.main.views.show" xform.user.username xform.id_string %}"><i class="fa fa-chevron-left"></i> {% trans "Return to" %} {{ xform.title }}</a>
+  </div>
+</div>
+
+<header class="data-page__header">
+    <hgroup class="container">
+      <h1>{% trans "Advanced Exports" %}</h1>
+    </hgroup>
+</header>
 
 {% block content %}
 
@@ -30,17 +41,6 @@ thead td {
 
 </style>
 
-<div class="sub-header-bar">
-  <div class="container__wide">
-    <a class="sub-header__back" href="{% url "onadata.apps.main.views.show" xform.user.username xform.id_string %}"><i class="fa fa-chevron-left"></i> {% trans "Return to" %} {{ xform.title }}</a>
-  </div>
-</div>
-
-<header class="data-page__header">
-    <hgroup class="container">
-      <h1>{% trans "Advanced Exports" %}</h1>
-    </hgroup>
-</header>
 
 <form action="."
       method="get" accept-charset="utf-8">


### PR DESCRIPTION
This simply moves the header elements in the right location of the template (outside of the `block content`) for auto reports and advanced exports.