### PR TITLE
Logic to fix mismatched root node names

### DIFF
--- a/docker/run_celery.bash
+++ b/docker/run_celery.bash
@@ -7,7 +7,7 @@ CELERYD_TASK_SOFT_TIME_LIMIT="${CELERYD_TASK_SOFT_TIME_LIMIT:-$((15*60))}"
 # Give tasks 1 minute for exception handling and cleanup before killing timed out Celery processes.
 CELERYD_TASK_TIME_LIMIT="${CELERYD_TASK_TIME_LIMIT:-$((${CELERYD_TASK_SOFT_TIME_LIMIT}+60))}"
 
-CELERYD_OPTIONS="--loglevel=DEBUG --soft-time-limit=${CELERYD_TASK_SOFT_TIME_LIMIT} --time-limit=${CELERYD_TASK_TIME_LIMIT} --maxtasksperchild=5"
+CELERYD_OPTIONS="--beat --loglevel=DEBUG --soft-time-limit=${CELERYD_TASK_SOFT_TIME_LIMIT} --time-limit=${CELERYD_TASK_TIME_LIMIT} --maxtasksperchild=5"
 
 cd "${KOBOCAT_SRC_DIR}"
 

--- a/onadata/apps/logger/management/commands/fix_root_node_names.py
+++ b/onadata/apps/logger/management/commands/fix_root_node_names.py
@@ -1,0 +1,115 @@
+import time
+from xml.dom import minidom
+from django.core.management.base import BaseCommand, CommandError
+from onadata.apps.logger.models import XForm, Instance
+
+AUTO_NAME_INSTANCE_XML_SEARCH_STRING = 'uploaded_form_'
+
+def replace_first_and_last(s, old, new):
+    s = s.replace(old, new, 1)
+    # credit: http://stackoverflow.com/a/2556252
+    return new.join(s.rsplit(old, 1))
+
+def get_xform_root_node_name(xform):
+    parsed = minidom.parseString(xform.xml.encode('utf-8'))
+    instance_xml = parsed.getElementsByTagName('instance')[0]
+    root_node_name = None
+    for child in instance_xml.childNodes:
+        if child.nodeType == child.ELEMENT_NODE:
+            root_node_name = child.nodeName
+            break
+    return root_node_name
+
+def write_same_line(stdout, output, last_len=[0]):
+    stdout.write(u'\r{}'.format(output), ending='')
+    this_len = len(output)
+    too_short = last_len[0] - this_len
+    last_len[0] = this_len
+    if too_short > 0:
+        stdout.write(' ' * too_short, ending='')
+    stdout.flush()
+
+class Command(BaseCommand):
+    ''' This command cleans up inconsistences between the root instance node
+    name specified in the form XML and the actual instance XML. Where a
+    discrepancy exists, the instance will be changed to match the form.
+    The cause of these mismatches is documented at
+    https://github.com/kobotoolbox/kobocat/issues/222. See also
+    https://github.com/kobotoolbox/kobocat/issues/242. '''
+
+    help = 'fixes instances whose root node names do not match their forms'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--minimum-instance-id',
+            type=int,
+            help='consider only instances whose ID is greater than or equal '\
+                 'to this number'
+        )
+        parser.add_argument(
+            '--username',
+            help='consider only forms belonging to a particular user'
+        )
+
+    def handle(self, *args, **options):
+        t0 = time.time()
+        forms_complete = 0
+        mismatch_count = 0
+        criteria = {'xml__contains': AUTO_NAME_INSTANCE_XML_SEARCH_STRING}
+        if options['minimum_instance_id']:
+            criteria['id__gte'] = options['minimum_instance_id']
+        if options['username']:
+            criteria['xform__user__username'] = options['username']
+        kpi_auto_named_instances = Instance.objects.filter(**criteria)
+        affected_xforms = XForm.objects.filter(
+            id__in=kpi_auto_named_instances.values_list(
+                'xform_id', flat=True).distinct()
+        )
+        if options['verbosity']:
+            self.stdout.write('Running slow query... ', ending='')
+            self.stdout.flush()
+        total_forms = affected_xforms.count()
+        for xform in affected_xforms.iterator():
+            xform_root_node_name = get_xform_root_node_name(xform)
+            affected_instances = xform.instances.exclude(
+                xml__endswith='</{}>'.format(xform_root_node_name))
+            for instance in affected_instances:
+                root_node_name = instance.get_root_node_name()
+                # Our crude `affected_instances` filter saves us a lot of work,
+                # but it doesn't account for things like trailing
+                # whitespace--so there might not really be a discrepancy
+                if xform_root_node_name != root_node_name:
+                    instance.xml = replace_first_and_last(
+                        instance.xml, root_node_name, xform_root_node_name)
+                    instance.save(force=True)
+                    mismatch_count += 1
+                if options['verbosity']:
+                    write_same_line(
+                        self.stdout,
+                        u'Form {} ({}): corrected instance {}. ' \
+                        'Completed {} of {} forms.'.format(
+                            xform_root_node_name,
+                            xform.id,
+                            instance.id,
+                            forms_complete,
+                            total_forms
+                    ))
+            forms_complete += 1
+            if options['verbosity']:
+                write_same_line(
+                    self.stdout,
+                    u'Form {} ({}). Completed {} of {} forms.'.format(
+                        xform_root_node_name,
+                        xform.id,
+                        forms_complete,
+                        total_forms
+                ))
+        t1 = time.time()
+        if options['verbosity']:
+            self.stdout.write('')
+            self.stdout.write(
+                'Corrected {} instances in {} minutes and {} seconds.'.format(
+                    mismatch_count,
+                    int((t1 - t0) / 60),
+                    (t1 - t0) % 60
+            ))

--- a/onadata/apps/logger/management/commands/fix_root_node_names.py
+++ b/onadata/apps/logger/management/commands/fix_root_node_names.py
@@ -60,6 +60,7 @@ class Command(BaseCommand):
             criteria['id__gte'] = options['minimum_instance_id']
         if options['username']:
             criteria['xform__user__username'] = options['username']
+        last_instance = Instance.objects.last()
         kpi_auto_named_instances = Instance.objects.filter(**criteria)
         affected_xforms = XForm.objects.filter(
             id__in=kpi_auto_named_instances.values_list(
@@ -113,3 +114,7 @@ class Command(BaseCommand):
                     int((t1 - t0) / 60),
                     (t1 - t0) % 60
             ))
+            self.stdout.write(
+                'At the start of processing, the last instance ID ' \
+                'was {}.'.format(last_instance.pk)
+            )

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -1,0 +1,14 @@
+### ISSUE 242 TEMPORARY FIX ###
+# See https://github.com/kobotoolbox/kobocat/issues/242
+
+from celery import shared_task
+from django.core.management import call_command
+
+@shared_task(soft_time_limit=600, time_limit=900)
+def fix_root_node_names(minimum_instance_id):
+    call_command('fix_root_node_names',
+        minimum_instance_id=minimum_instance_id,
+        verbosity=0
+    )
+
+###### END ISSUE 242 FIX ######

--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -164,3 +164,18 @@ if 'RAVEN_DSN' in os.environ:
             pass
 
 POSTGIS_VERSION = (2, 1, 2)
+
+### ISSUE 242 TEMPORARY FIX ###
+# See https://github.com/kobotoolbox/kobocat/issues/242
+ISSUE_242_MINIMUM_INSTANCE_ID = os.environ.get(
+    'ISSUE_242_MINIMUM_INSTANCE_ID', None)
+if ISSUE_242_MINIMUM_INSTANCE_ID is not None:
+    from datetime import timedelta
+    CELERYBEAT_SCHEDULE = {
+        'fix-root-node-names': {
+            'task': 'onadata.apps.logger.tasks.fix_root_node_names',
+            'schedule': timedelta(hours=1),
+            'args': (int(ISSUE_242_MINIMUM_INSTANCE_ID),)
+        },
+    }
+###### END ISSUE 242 FIX ######


### PR DESCRIPTION
Fixes #242 

**Deployment requirements**

1. Run `./manage.py fix_root_node_names` once, manually and note the last instance ID;
1. Set `ISSUE_242_MINIMUM_INSTANCE_ID` equal to that instance ID in the environment;
1. Make sure Celery can see that environment variable;
1. Modify the Celery worker invocation to include `--beat` ([example](https://github.com/kobotoolbox/kobocat/compare/242-issue?expand=1#diff-7bfe1ebf2993514abe091c3d6bff396cR10)), otherwise the scheduled task won't run.