### PR TITLE
Remove unused `pylibmc` (Memcached).

### DIFF
--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -78,7 +78,4 @@ https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip#
 jsonfield<1.0
 django-db-readonly==0.3.2
 
-# memcached support
-pylibmc==1.3.0
-
 transifex-client


### PR DESCRIPTION
Only references to Memcached are:
https://github.com/kobotoolbox/kobocat/blob/master/onadata/settings/production_example.py#L68
https://github.com/kobotoolbox/kobocat/blob/master/script/install/macos#L9-L10
https://github.com/kobotoolbox/kobocat/blob/master/script/install/ubuntu#L22-L23