### PR TITLE
Configure useful Celery limits; fixes #250

### DIFF
--- a/onadata/apps/viewer/tasks.py
+++ b/onadata/apps/viewer/tasks.py
@@ -229,7 +229,7 @@ def create_kml_export(username, id_string, export_id, query=None):
         return gen_export.id
 
 
-@task(soft_time_limit=30*60, time_limit=31*60)
+@task()
 def create_zip_export(username, id_string, export_id, query=None):
     export = Export.objects.get(id=export_id)
     try:


### PR DESCRIPTION
...which can be overridden by environment variables:

* CELERYD_MAX_CONCURRENCY: lesser of 6 or number of CPU cores
* CELERYD_MAX_TASKS_PER_CHILD: 7
* CELERYD_TASK_TIME_LIMIT: 2100 seconds (35 minutes)
* CELERYD_TASK_SOFT_TIME_LIMIT: 1800 seconds (30 minutes)