### PR TITLE
Fixed `/api/v1/data/{pk}/{dataid}`, was different to docs and list view

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -75,12 +75,6 @@ class TestDataViewSet(TestBase):
         data = _data_instance(dataid)
         self.assertDictContainsSubset(data, sorted(response.data)[0])
 
-        data = {
-            u'_xform_id_string': u'transportation_2011_07_25',
-            u'transport/available_transportation_types_to_referral_facility':
-            u'none',
-            u'_submitted_by': u'bob',
-        }
         view = DataViewSet.as_view({'get': 'retrieve'})
         response = view(request, pk=formid, dataid=dataid)
         self.assertEqual(response.status_code, 200)

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -506,15 +506,8 @@ Delete a specific submission in a form
 
         try:
             instance = Instance.objects.get(pk=data_id)
-            if _format == 'json' or _format is None:
-                return Response(instance.json)
-            elif _format == 'xml':
-                return Response(instance.xml)
-            else:
-                raise ParseError(
-                    _(u"'%(_format)s' format unknown or not implemented!" %
-                      {'_format': _format})
-                )
+            serializer = self.get_serializer(instance)
+            return Response(serializer.data)
         except Instance.DoesNotExist:
             raise ParseError(
                 _(u"data with id '%(data_id)s' not found!" %


### PR DESCRIPTION
Fixes #259