### PR TITLE
Tolerate empty, nameless worksheets

### DIFF
--- a/onadata/koboform/pyxform_utils.py
+++ b/onadata/koboform/pyxform_utils.py
@@ -25,6 +25,9 @@ def convert_csv_to_xls(csv_repr):
     dict_repr = xls2json_backends.csv_to_dict(StringIO.StringIO(encoded_csv))
     workbook = xlwt.Workbook()
     for sheet_name in dict_repr.keys():
+        if not len(sheet_name) and not dict_repr[sheet_name]:
+            # Discard an empty sheet with no name
+            continue
         # pyxform.xls2json_backends adds "_header" items for each sheet.....
         if not re.match(r".*_header$", sheet_name):
             cur_sheet = workbook.add_sheet(sheet_name)


### PR DESCRIPTION
...in "sheeted CSV" form representations, e.g. `""` in

    settings
    ,form_title,version,id_string
    ,Sample Title,1234,sample_title
    choices
    ""
    survey
    [snip]

["Sheeted CSV" reference](https://github.com/kobotoolbox/kpi/blob/cd9ac187fa1fc6fc44c72c66ae56b265fa5944f7/jsapp/xlform/src/csv.coffee#L240)
[Flowdock discussion](https://www.flowdock.com/app/kobotoolbox/kobo/threads/RLV8oVNY9oi_8vDMoBZCvZ3-v_O)
[Support request](https://kobotoolbox.desk.com/agent/case/3190)