### PR TITLE
Use Dimagi's django-digest for proper 1.8 support

### DIFF
--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -32,8 +32,7 @@ librabbitmq==1.5.2
 amqp>1.4,<2.0
 django-nose==1.4.2
 python-digest==1.7
-#django-digest==1.13 # django-digest has no commits since 2011
--e git+https://github.com/jnm/django-digest#egg=django-digest
+-e git+https://github.com/dimagi/django-digest#egg=django-digest
 -e git+https://github.com/onaio/python-json2xlsclient.git#egg=j2xclient
 
 # new export code relies on


### PR DESCRIPTION
Fixes `'module' object has no attribute 'backend'`

Dimagi merged [my PR](https://github.com/dimagi/django-digest/pull/16) long ago, so there's no need to keep using my repository. Unfortunately, PyPI is still very out-of-date, having been last updated 2011-03-04.