### PR TITLE
Preserve correct media directory in Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "db:*:*:kobo:kobo" > /root/.pgpass && \
 # Using `/etc/profile.d/` as a repository for non-hard-coded environment variable overrides.
 RUN echo 'source /etc/profile' >> /root/.bashrc
 
-VOLUME ["${KOBOCAT_SRC_DIR}", "${KOBOCAT_SRC_DIR}/onadata/media", "/srv/src/kobocat-template"]
+VOLUME ["${KOBOCAT_SRC_DIR}", "${KOBOCAT_SRC_DIR}/media", "/srv/src/kobocat-template"]
 
 WORKDIR "${KOBOCAT_SRC_DIR}"
 


### PR DESCRIPTION
[`MEDIA_ROOT`](https://github.com/kobotoolbox/kobocat/blob/master/onadata/settings/kc_environ.py#L70) location changed since [change to `PROJECT_ROOT` in `4b2b30`](https://github.com/kobotoolbox/kobocat/commit/4b2b30bd4c93c967bd219c66fb81a6816f24d9f6#diff-fe503402bfe64d2b53a020632d2aacb7R28).

Inspired by kobotoolbox/kobo-docker#68.