### PR TITLE
Invoke the Celery worker with `-Ofair`; fixes #329

### DIFF
--- a/docker/run_celery.bash
+++ b/docker/run_celery.bash
@@ -3,11 +3,7 @@ set -e
 
 source /etc/profile
 
-CELERYD_TASK_SOFT_TIME_LIMIT="${CELERYD_TASK_SOFT_TIME_LIMIT:-$((15*60))}"
-# Give tasks 1 minute for exception handling and cleanup before killing timed out Celery processes.
-CELERYD_TASK_TIME_LIMIT="${CELERYD_TASK_TIME_LIMIT:-$((${CELERYD_TASK_SOFT_TIME_LIMIT}+60))}"
-
-CELERYD_OPTIONS="--beat --loglevel=DEBUG --soft-time-limit=${CELERYD_TASK_SOFT_TIME_LIMIT} --time-limit=${CELERYD_TASK_TIME_LIMIT} --maxtasksperchild=5"
+CELERYD_OPTIONS="-Ofair --beat --loglevel=DEBUG"
 
 cd "${KOBOCAT_SRC_DIR}"
 


### PR DESCRIPTION
Should avoid worker subprocesses sitting idle despite many queued jobs. Other
change: remove time limit and tasks per child settings from the command line
since b6e30094 provides for them to be specified in environment variables