### PR TITLE
Upgrade reversion to 2.0.8. Read WARNING below!

### DIFF
--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -21,7 +21,7 @@ lxml==3.4.0
 #-e git+https://github.com/onaio/pyxform.git@onaio#egg=pyxform
 # kobo fork supports csvs with utf, character escaping, etc.
 -e git+https://github.com/kobotoolbox/pyxform.git#egg=pyxform-dev
-django-reversion==1.8.4
+django-reversion==2.0.8
 xlrd==0.9.3
 xlwt==0.7.5
 openpyxl==2.0.5


### PR DESCRIPTION
If your database is large, the migration included in this update of
django-reversion will be slow. For example, on a database with 3.3 million rows
in the `reversion_version` table, the migration takes about 20 minutes. This
can be reduced to around 7 minutes on the same size of database by checking out
commit e822bb1 (from https://github.com/etianen/django-reversion/pull/611).