### PR TITLE
Add "_id" field to Browse Form Data view

### DIFF
--- a/onadata/apps/viewer/static/js/instance.js
+++ b/onadata/apps/viewer/static/js/instance.js
@@ -49,6 +49,10 @@ function parseQuestions(children, prefix, cleanReplacement)
             questions[((prefix?prefix:'') + question.name)] = new Question(question);
         }
     }
+    if (typeof prefix === 'undefined') {
+      questions['_id'] = new Question(
+        {name: '_id', type: 'calculate', label: '_id'});
+    }
 }
 
 function addOrEditNote(){


### PR DESCRIPTION
This adds __id_ field to "Browse Form Data" view's table (`/<username>/forms/<form-id>/instance#/<submission-no>`)

I'm not sure about whether this patch's quality is appropriate (as the column is essentially hardcoded in the js source). Let me know if there's a nicer place to put that in.