### PR TITLE
Generate `superuser_stats` ZIP asynchronously

### DIFF
--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -12,3 +12,100 @@ def fix_root_node_names(minimum_instance_id):
     )
 
 ###### END ISSUE 242 FIX ######
+
+import csv
+import datetime
+import zipfile
+from io import BytesIO
+from django.contrib.auth.models import User
+from django.core.files.storage import get_storage_class
+from .models import Instance, XForm
+
+@shared_task
+def generate_stats_zip(output_filename):
+    REPORTS = {
+        'instances.csv': {
+            'model': Instance,
+            'date_field': 'date_created'
+        },
+        'xforms.csv': {
+            'model': XForm,
+            'date_field': 'date_created'
+        },
+        'users.csv': {
+            'model': User,
+            'date_field': 'date_joined'
+        }
+    }
+
+    def first_day_of_next_month(any_date):
+        return datetime.date(
+            year=any_date.year if any_date.month < 12 else any_date.year + 1,
+            month=any_date.month + 1 if any_date.month < 12 else 1,
+            day=1
+        )
+
+    def first_day_of_previous_month(any_date):
+        return datetime.date(
+            year=any_date.year if any_date.month > 1 else any_date.year - 1,
+            month=any_date.month - 1 if any_date.month > 1 else 12,
+            day=1
+    )
+
+    def list_created_by_month(model, date_field):
+        today = datetime.date.today()
+        # Just start at January 1 of the previous year. Going back to the
+        # oldest object would be great, but it's too slow right now. Django
+        # 1.10 will provide a more efficient way:
+        # https://docs.djangoproject.com/en/1.10/ref/models/database-functions/#trunc
+        first_date = datetime.date(
+            year=today.year - 1,
+            month=1,
+            day=1
+        )
+        # We *ASSUME* that primary keys increase cronologically!
+        last_object = model.objects.order_by('pk').last()
+        last_date = first_day_of_next_month(getattr(last_object, date_field))
+        year_month_count = []
+        while last_date > first_date:
+            this_start_date = first_day_of_previous_month(last_date)
+            this_end_date = last_date
+            criteria = {
+                '{}__gte'.format(date_field): this_start_date,
+                '{}__lt'.format(date_field): this_end_date
+            }
+            objects_this_month = model.objects.filter(**criteria).count()
+            year_month_count.append((
+                this_start_date.year,
+                this_start_date.month,
+                objects_this_month
+            ))
+            last_date = this_start_date
+        return year_month_count
+
+    default_storage = get_storage_class()()
+
+    with default_storage.open(output_filename, 'wb') as output_file:
+        zip_file = zipfile.ZipFile(output_file, 'w', zipfile.ZIP_DEFLATED)
+
+        for filename, report_settings in REPORTS.iteritems():
+            model_name_plural = report_settings[
+                'model']._meta.verbose_name_plural
+            fieldnames = [
+                'Year',
+                'Month',
+                'New {}'.format(model_name_plural.capitalize()),
+                'NOTE: Records created prior to January 1 of last '
+                'year are NOT included in this report!'
+            ]
+            data = list_created_by_month(
+                report_settings['model'], report_settings['date_field'])
+            csv_io = BytesIO()
+            writer = csv.DictWriter(csv_io, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in data:
+                writer.writerow(dict(zip(fieldnames, row)))
+            zip_file.writestr(filename, csv_io.getvalue())
+            csv_io.close()
+
+        zip_file.close()

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -15,6 +15,7 @@ def fix_root_node_names(minimum_instance_id):
 
 import csv
 import datetime
+import pytz
 import zipfile
 from io import BytesIO
 from django.contrib.auth.models import User
@@ -50,7 +51,15 @@ def generate_stats_zip(output_filename):
             year=any_date.year if any_date.month > 1 else any_date.year - 1,
             month=any_date.month - 1 if any_date.month > 1 else 12,
             day=1
-    )
+        )
+
+    def utc_midnight(any_date):
+        return datetime.datetime(
+            year=any_date.year,
+            month=any_date.month,
+            day=any_date.day,
+            tzinfo=pytz.UTC
+        )
 
     def list_created_by_month(model, date_field):
         today = datetime.date.today()
@@ -71,8 +80,8 @@ def generate_stats_zip(output_filename):
             this_start_date = first_day_of_previous_month(last_date)
             this_end_date = last_date
             criteria = {
-                '{}__gte'.format(date_field): this_start_date,
-                '{}__lt'.format(date_field): this_end_date
+                '{}__gte'.format(date_field): utc_midnight(this_start_date),
+                '{}__lt'.format(date_field): utc_midnight(this_end_date)
             }
             objects_this_month = model.objects.filter(**criteria).count()
             year_month_count.append((

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -777,7 +777,9 @@ def superuser_stats(request, username):
     template_ish = (
         '<html><head><title>Hello, superuser.</title></head>'
         '<body>Your report is being generated. Once finished, it will be '
-        'available at <a href="{0}">{0}</a>.</body></html>'
+        'available at <a href="{0}">{0}</a>. If you receive a 404, please '
+        'refresh your browser periodically until your request succeeds.'
+        '</body></html>'
     ).format(base_filename)
     return HttpResponse(template_ish)
 

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -3,10 +3,7 @@ import datetime as datetime_module
 import json
 import os
 import tempfile
-import csv
 import re
-import zipfile
-from io import BytesIO
 
 import pytz
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -23,6 +20,7 @@ from django.http import (HttpResponse,
                          HttpResponseRedirect,
                          HttpResponseServerError,
                          StreamingHttpResponse,
+                         Http404,
                          )
 from django.shortcuts import get_object_or_404
 from django.shortcuts import render
@@ -65,6 +63,7 @@ from onadata.libs.utils.user_auth import (helper_auth_helper,
                                           )
 from onadata.libs.utils.viewer_tools import _get_form_url
 from ...koboform.pyxform_utils import convert_csv_to_xls
+from .tasks import generate_stats_zip
 
 IO_ERROR_STRINGS = [
     'request data read error',
@@ -764,91 +763,36 @@ def ziggy_submissions(request, username):
 
 @user_passes_test(lambda u: u.is_superuser)
 def superuser_stats(request, username):
-    REPORTS = {
-        'instances.csv': {
-            'model': Instance,
-            'date_field': 'date_created'
-        },
-        'xforms.csv': {
-            'model': XForm,
-            'date_field': 'date_created'
-        },
-        'users.csv': {
-            'model': User,
-            'date_field': 'date_joined'
-        }
-    }
-
-    def first_day_of_next_month(any_date):
-        return datetime_module.date(
-            year=any_date.year if any_date.month < 12 else any_date.year + 1,
-            month=any_date.month + 1 if any_date.month < 12 else 1,
-            day=1
-        )
-
-    def first_day_of_previous_month(any_date):
-        return datetime_module.date(
-            year=any_date.year if any_date.month > 1 else any_date.year - 1,
-            month=any_date.month - 1 if any_date.month > 1 else 12,
-            day=1
-    )
-
-    def list_created_by_month(model, date_field):
-        today = datetime_module.date.today()
-        # Just start at January 1 of the previous year. Going back to the
-        # oldest object would be great, but it's too slow right now. Django
-        # 1.10 will provide a more efficient way:
-        # https://docs.djangoproject.com/en/1.10/ref/models/database-functions/#trunc
-        first_date = datetime_module.date(
-            year=today.year - 1,
-            month=1,
-            day=1
-        )
-        # We *ASSUME* that primary keys increase cronologically!
-        last_object = model.objects.order_by('pk').last()
-        last_date = first_day_of_next_month(getattr(last_object, date_field))
-        year_month_count = []
-        while last_date > first_date:
-            this_start_date = first_day_of_previous_month(last_date)
-            this_end_date = last_date
-            criteria = {
-                '{}__gte'.format(date_field): this_start_date,
-                '{}__lt'.format(date_field): this_end_date
-            }
-            objects_this_month = model.objects.filter(**criteria).count()
-            year_month_count.append((
-                this_start_date.year,
-                this_start_date.month,
-                objects_this_month
-            ))
-            last_date = this_start_date
-        return year_month_count
-
-    response = HttpResponse(content_type='application/zip')
-    response['Content-Disposition'] = 'attachment;filename="{}_{}.zip"'.format(
+    base_filename = '{}_{}_{}.zip'.format(
         re.sub('[^a-zA-Z0-9]', '-', request.META['HTTP_HOST']),
-        datetime_module.date.today()
+        datetime_module.date.today(),
+        datetime_module.datetime.now().microsecond
     )
-    zip_file = zipfile.ZipFile(response, 'w', zipfile.ZIP_DEFLATED)
+    filename = os.path.join(
+        request.user.username,
+        'superuser_stats',
+        base_filename
+    )
+    generate_stats_zip.delay(filename)
+    template_ish = (
+        '<html><head><title>Hello, superuser.</title></head>'
+        '<body>Your report is being generated. Once finished, it will be '
+        'available at <a href="{0}">{0}</a>.</body></html>'
+    ).format(base_filename)
+    return HttpResponse(template_ish)
 
-    for filename, report_settings in REPORTS.iteritems():
-        model_name_plural = report_settings['model']._meta.verbose_name_plural
-        fieldnames = [
-            'Year',
-            'Month',
-            'New {}'.format(model_name_plural.capitalize()),
-            'NOTE: Records created prior to January 1 of last '
-            'year are NOT included in this report!'
-        ]
-        data = list_created_by_month(
-            report_settings['model'], report_settings['date_field'])
-        csv_io = BytesIO()
-        writer = csv.DictWriter(csv_io, fieldnames=fieldnames)
-        writer.writeheader()
-        for row in data:
-            writer.writerow(dict(zip(fieldnames, row)))
-        zip_file.writestr(filename, csv_io.getvalue())
-        csv_io.close()
-
-    zip_file.close()
-    return response
+@user_passes_test(lambda u: u.is_superuser)
+def retrieve_superuser_stats(request, username, base_filename):
+    filename = os.path.join(
+        request.user.username,
+        'superuser_stats',
+        base_filename
+    )
+    default_storage = get_storage_class()()
+    if not default_storage.exists(filename):
+        raise Http404
+    with default_storage.open(filename) as f:
+        response = StreamingHttpResponse(f, content_type='application/zip')
+        response['Content-Disposition'] = 'attachment;filename="{}"'.format(
+            base_filename)
+        return response

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -278,7 +278,11 @@ urlpatterns = patterns(
     # Statistics for superusers. The username is irrelevant, but leave it as
     # the first part of the path to avoid collisions
     url(r"^(?P<username>[^/]+)/superuser_stats/$",
-        'onadata.apps.logger.views.superuser_stats'))
+        'onadata.apps.logger.views.superuser_stats'),
+    url(r"^(?P<username>[^/]+)/superuser_stats/(?P<base_filename>[^/]+)$",
+        'onadata.apps.logger.views.retrieve_superuser_stats'),
+
+)
 
 urlpatterns += patterns('django.contrib.staticfiles.views',
                         url(r'^static/(?P<path>.*)$', 'serve'))

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -1,7 +1,7 @@
 # pybamboo has deps in common but on newer versions.
 # on top so those will be overwritten
 pybamboo==0.5.8.1
-pytz==2014.7
+pytz==2016.10
 
 Django>=1.8,<1.9
 dj-database-url==0.4.0

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -1,2 +1,2 @@
-boto==2.1.1
-django-storages==1.1.4
+boto==2.46.1
+django-storages==1.5.2


### PR DESCRIPTION
Quick-and-dirty; fixes #340. URL remains `https://server/username/superuser_stats`, but now that view kicks off a Celery task and returns the destination filename immediately, while the contents of the report are generated in the background.