### PR TITLE
Rewrite `fix_root_node_names`; fixes #361

### DIFF
--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -5,10 +5,10 @@ from celery import shared_task
 from django.core.management import call_command
 
 @shared_task(soft_time_limit=600, time_limit=900)
-def fix_root_node_names(minimum_instance_id):
+def fix_root_node_names(**kwargs):
     call_command(
         'fix_root_node_names',
-        minimum_instance_id=minimum_instance_id,
+        **kwargs
     )
 
 ###### END ISSUE 242 FIX ######

--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -179,13 +179,18 @@ POSTGIS_VERSION = (2, 1, 2)
 # See https://github.com/kobotoolbox/kobocat/issues/242
 ISSUE_242_MINIMUM_INSTANCE_ID = os.environ.get(
     'ISSUE_242_MINIMUM_INSTANCE_ID', None)
+ISSUE_242_INSTANCE_XML_SEARCH_STRING = os.environ.get(
+    'ISSUE_242_INSTANCE_XML_SEARCH_STRING', 'uploaded_form_')
 if ISSUE_242_MINIMUM_INSTANCE_ID is not None:
     from datetime import timedelta
     CELERYBEAT_SCHEDULE = {
         'fix-root-node-names': {
             'task': 'onadata.apps.logger.tasks.fix_root_node_names',
             'schedule': timedelta(hours=1),
-            'args': (int(ISSUE_242_MINIMUM_INSTANCE_ID),)
+            'kwargs': {
+                'pk__gte': int(ISSUE_242_MINIMUM_INSTANCE_ID),
+                'xml__contains': ISSUE_242_INSTANCE_XML_SEARCH_STRING
+            }
         },
     }
 ###### END ISSUE 242 FIX ######


### PR DESCRIPTION
* Set `ISSUE_242_INSTANCE_XML_SEARCH_STRING` to an empty string in the
    environment to consider all `Instance`s. Otherwise, it defaults to
    `uploaded_form_` for backwards compatibility
* Completes in 5 minutes on a database with 3 mil. `Instance`s and
    10,000+ corrections needed