### PR TITLE
reflect intended name rather than filename

### DIFF
--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -148,6 +148,9 @@ class DataDictionary(XForm):
     def save(self, *args, **kwargs):
         if self.xls:
             survey = create_survey_from_xls(self.xls)
+            survey.update({
+                'name': survey.id_string,
+            })
             self.json = survey.to_json()
             self.xml = survey.to_xml()
             self._mark_start_time_boolean()


### PR DESCRIPTION
Update the pyxform.survey.Survey object to reflect
the intended name (rather than the name pulled from
the filename)

Mimics code in formpack that explicitly sets root
node name:

https://github.com/kobotoolbox/formpack/commit/048c53fe96c7681ac806cbc90615353c7b988782#diff-f6ef579a49ba75d5146b5a04da43002dR93

closes #358