### PR TITLE
Log warnings for stuck exports; mark them "failed"

### DIFF
--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -174,6 +174,53 @@ if 'RAVEN_DSN' in os.environ:
         except raven.exceptions.InvalidGitRepository:
             pass
 
+        # The below is NOT required for Sentry to log unhandled exceptions, but it
+        # is necessary for capturing messages sent via the `logging` module.
+        # https://docs.getsentry.com/hosted/clients/python/integrations/django/#integration-with-logging
+        LOGGING = {
+            'version': 1,
+            'disable_existing_loggers': False, # Was `True` in Sentry documentation
+            'root': {
+                'level': 'WARNING',
+                'handlers': ['sentry'],
+            },
+            'formatters': {
+                'verbose': {
+                    'format': '%(levelname)s %(asctime)s %(module)s '
+                              '%(process)d %(thread)d %(message)s'
+                },
+            },
+            'handlers': {
+                'sentry': {
+                    'level': 'WARNING',
+                    'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+                },
+                'console': {
+                    'level': 'DEBUG',
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'verbose'
+                }
+            },
+            'loggers': {
+                'django.db.backends': {
+                    'level': 'ERROR',
+                    'handlers': ['console'],
+                    'propagate': False,
+                },
+                'raven': {
+                    'level': 'DEBUG',
+                    'handlers': ['console'],
+                    'propagate': False,
+                },
+                'sentry.errors': {
+                    'level': 'DEBUG',
+                    'handlers': ['console'],
+                    'propagate': False,
+                },
+            },
+        }
+        CELERYD_HIJACK_ROOT_LOGGER = False
+
 POSTGIS_VERSION = (2, 1, 2)
 
 CELERYBEAT_SCHEDULE = {

--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 from onadata.settings.common import *
 
 
@@ -175,6 +176,15 @@ if 'RAVEN_DSN' in os.environ:
 
 POSTGIS_VERSION = (2, 1, 2)
 
+CELERYBEAT_SCHEDULE = {
+    # Periodically mark exports stuck in the "pending" state as "failed"
+    # See https://github.com/kobotoolbox/kobocat/issues/315
+    'log-stuck-exports-and-mark-failed': {
+        'task': 'onadata.apps.viewer.tasks.log_stuck_exports_and_mark_failed',
+        'schedule': timedelta(hours=6),
+    },
+}
+
 ### ISSUE 242 TEMPORARY FIX ###
 # See https://github.com/kobotoolbox/kobocat/issues/242
 ISSUE_242_MINIMUM_INSTANCE_ID = os.environ.get(
@@ -182,15 +192,12 @@ ISSUE_242_MINIMUM_INSTANCE_ID = os.environ.get(
 ISSUE_242_INSTANCE_XML_SEARCH_STRING = os.environ.get(
     'ISSUE_242_INSTANCE_XML_SEARCH_STRING', 'uploaded_form_')
 if ISSUE_242_MINIMUM_INSTANCE_ID is not None:
-    from datetime import timedelta
-    CELERYBEAT_SCHEDULE = {
-        'fix-root-node-names': {
-            'task': 'onadata.apps.logger.tasks.fix_root_node_names',
-            'schedule': timedelta(hours=1),
+    CELERYBEAT_SCHEDULE['fix-root-node-names'] = {
+        'task': 'onadata.apps.logger.tasks.fix_root_node_names',
+        'schedule': timedelta(hours=1),
             'kwargs': {
                 'pk__gte': int(ISSUE_242_MINIMUM_INSTANCE_ID),
                 'xml__contains': ISSUE_242_INSTANCE_XML_SEARCH_STRING
             }
-        },
     }
 ###### END ISSUE 242 FIX ######


### PR DESCRIPTION
Fixes #315. Failures will be sent to Sentry (if Raven is enabled).