### PR TITLE
Change the name of the csrf token cookie

### DIFF
--- a/onadata/apps/main/static/js/application.js
+++ b/onadata/apps/main/static/js/application.js
@@ -1,5 +1,7 @@
 $(document).ready(function(){
 
+    var CSRF_TOKEN_KEY = 'kobo_csrftoken';
+
     // table sort example
     // ==================
 
@@ -76,7 +78,7 @@ $(document).ready(function(){
         }
 
         if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
-            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+            xhr.setRequestHeader("X-CSRFToken", getCookie(CSRF_TOKEN_KEY));
         }
     });
     // END CSRF Protection for AJAX

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -120,6 +120,14 @@ ENKETO_PROTOCOL = os.environ.get('ENKETO_PROTOCOL', 'https')
 LOGIN_URL = '/accounts/login/'
 LOGIN_REDIRECT_URL = '/login_redirect/'
 
+# XXX: Since KoBo Toolbox's set of applications is using multiple subdomains,
+# the CSRF cookie is established on a wildcard domain, so that it is accessible
+# on all of the subdomains. That said, the generic `csrftoken` name might cause
+# collisions with other django apps deployed on the same domain. This leads to
+# issue where wrong CSRF token might be accepted in the django app, thus,
+# breaking POST requests in the django app.
+CSRF_COOKIE_NAME = 'kobo_csrftoken'
+
 # URL prefix for admin static files -- CSS, JavaScript and images.
 # Make sure to use a trailing slash.
 # Examples: "http://foo.com/static/admin/", "/static/admin/".


### PR DESCRIPTION
This change is pretty crucial for everyone that runs other django applications on subdomains on the same domain that is used as a kobotoolbox base.

Exemplary case:
`kobo.example.com` - Kobotoolbox app
`other_app.example.com` - Other, not related to the above django app

The kobo's cookie is established on wildcard `*.example.com` domain, thus, it is also accessible on the other_app. Assuming that the other_app is also a django application, it will break the POST request since wrong csrf token might be used for request authorization. Please also see the comment in the code for the refrence.

The patch is already tested on production machine, and appears to be working correctly.  Please note that this change and according Kpi pull request should be submitted simultaneously, since submitting only one would break the app.

Related KPI change: https://github.com/kobotoolbox/kpi/pull/1428