### PR TITLE
Data migration tool

### DIFF
--- a/onadata/apps/logger/data_migration/backup_data.py
+++ b/onadata/apps/logger/data_migration/backup_data.py
@@ -1,0 +1,22 @@
+from onadata.apps.logger.models.backup import BackupInstance, BackupXForm
+
+
+def backup_xform(xform):
+    """Create backup of xform version before changing schema."""
+    return BackupXForm.objects.create(
+        xls=xform.xls,
+        json=xform.json,
+        xml=xform.xml,
+        description=xform.description,
+        user=xform.user,
+        date_created=xform.date_created,
+    )
+
+
+def backup_survey(survey, backup_xform):
+    return BackupInstance.objects.create(
+        xml=survey.xml,
+        xform=backup_xform,
+        user=survey.user,
+        date_created=survey.date_created,
+    )

--- a/onadata/apps/logger/data_migration/compare_xml.py
+++ b/onadata/apps/logger/data_migration/compare_xml.py
@@ -1,0 +1,90 @@
+from .xformtree import XFormTree
+
+
+class XFormsComparator(object):
+    """
+    Compare XML of two xforms.
+
+    This parser looks for differences between added / removed / modified:
+    - title
+    - fields
+    - fields types
+    - field obligations
+    - selects values
+
+    Output human readable results afterwards
+
+    Example XML files are available in
+    `onadata.apps.logger.tests.data_migration.fixtures`
+    """
+    def __init__(self, prev_xml, new_xml):
+        self.prev_tree = XFormTree(prev_xml)
+        self.new_tree = XFormTree(new_xml)
+
+    def clean_tag(self, tag):
+        return self.prev_tree.clean_tag(tag)
+
+    def fields_diff(self):
+        """
+        Difference between fields. Returns tuple of two lists where
+        first one contains added and second one contains
+        removed fields in new xml form file.
+        """
+        added = self.new_tree.added_fields(self.prev_tree)
+        removed = self.prev_tree.added_fields(self.new_tree)
+        return added, removed
+
+    def fields_type_diff(self):
+        """
+        Differences between fields types.
+        Returns dictionary with changed types
+        Output: {'field_name': 'changed_type'}
+        """
+        prev_types = self.prev_tree.get_fields_types()
+        new_types = self.new_tree.get_fields_types()
+        return {
+            key: new_types[key]
+            for key, val in prev_types.items()
+            if key in new_types and val != new_types[key]
+        }
+
+    def titles_diff(self):
+        if self.prev_tree.get_title() != self.new_tree.get_title():
+            return self.new_tree.get_title()
+        return ''
+
+    def selects_diff(self):
+        """
+        Checks whether select have any new or removed options.
+        Returns tuple of two dictionaries with added and removed values
+        Example: {'gender': ['unknown']}
+        """
+        added = self.new_tree.added_select_options(self.prev_tree)
+        removed = self.prev_tree.added_select_options(self.new_tree)
+        return added, removed
+
+    def input_obligation_diff(self):
+        """Difference if inputs became (un)required."""
+        prev_oblig = self.prev_tree.get_fields_obligation()
+        new_oblig = self.new_tree.get_fields_obligation()
+        return {
+            key: new_oblig[key]
+            for key, val in prev_oblig.items()
+            if key in new_oblig and val != new_oblig[key]
+        }
+
+    def pprint_dict(self, **data):
+        result = ''
+        for key, val in data.items():
+            result += "Name: {}, new value: {}\n".format(key, val)
+        return result or ''
+
+    def comparison_results(self):
+        return {
+            'new_title': (self.titles_diff() or ''),
+            'fields_added': self.fields_diff()[0],
+            'fields_removed': self.fields_diff()[1],
+            'fields_type_diff': self.pprint_dict(**self.fields_type_diff()),
+            'input_obligation_diff': (
+                self.pprint_dict(**self.input_obligation_diff()))
+        }

--- a/onadata/apps/logger/data_migration/decisioner.py
+++ b/onadata/apps/logger/data_migration/decisioner.py
@@ -1,0 +1,74 @@
+
+
+class MigrationDecisioner(object):
+    """
+    This class provides an neat encapsulation of user decisions format.
+    Migration decisions format specification:
+
+    1) determine_<field_name>: <modified_field> OR
+      Each tag of given <field_name> will be updated with new,
+      modified value. Data remains unchanged.
+      Use case: user fix typo in field name
+
+    2) determine_<field_name>: __new_field__
+
+    3) prepopulate_<field_name>: <value>
+      For each previous record (survey answer), fill new field (<field_name>)
+      with given value.
+
+    Example:
+    decisions = {
+        'determine_geender': 'gender',
+        'determine_age': '__new_field__',
+        'prepopulate_name': 'Martin',
+        'prepopulate_last_name': 'Fowler',
+    }
+    """
+    NEW_FIELD = '__new_field__'
+
+    def __init__(self, xforms_comparator, **data):
+        self._decisions = self._extract_migration_decisions(**data)
+        self.xforms_comparator = xforms_comparator
+
+        added, potentiall_removed = self.xforms_comparator.fields_diff()
+        self.removed_fields = self.get_removed_fields(potentiall_removed)
+        self.new_fields = self.get_new_fields(added)
+        self.modifications = self.get_fields_modifications(potentiall_removed)
+
+    def _extract_migration_decisions(self, **data):
+        return {
+            key: value[0] for key, value in data.iteritems()
+            if 'prepopulate_' in key or 'determine_' in key
+        }
+
+    def _get_determined_field(self, field_name):
+        return self._decisions.get('determine_' + field_name)
+
+    def _get_decision_key_by_value(self, field_name):
+        for key, value in self._decisions.iteritems():
+            if value == field_name:
+                return key.replace('determine_', '')
+        return ''
+
+    def get_prepopulate_text(self, field_name):
+        return self._decisions.get('prepopulate_' + field_name) or ''
+
+    def get_removed_fields(self, potentiall_removed):
+        return [
+            removed_field for removed_field in potentiall_removed
+            if not self._get_decision_key_by_value(removed_field)
+        ]
+
+    def get_new_fields(self, added):
+        return [
+            added_field for added_field in added
+            if self._get_determined_field(added_field) == self.NEW_FIELD
+        ]
+
+    def get_fields_modifications(self, potentiall_removed):
+        result = {}
+        for removed_field in potentiall_removed:
+            decision_val = self._get_decision_key_by_value(removed_field)
+            if decision_val and decision_val != self.NEW_FIELD:
+                result.update({removed_field: decision_val})
+        return result

--- a/onadata/apps/logger/data_migration/factories.py
+++ b/onadata/apps/logger/data_migration/factories.py
@@ -1,0 +1,17 @@
+from .migrate_data import DataMigrator, SurveyFieldsHandler
+from .decisioner import MigrationDecisioner
+from .compare_xml import XFormsComparator
+
+
+def migration_decisioner_factory(old_xform, new_xform, **request_data):
+    xforms_comparator = XFormsComparator(old_xform.xml, new_xform.xml)
+    migration_decisioner = MigrationDecisioner(xforms_comparator, **request_data)
+    return migration_decisioner
+
+
+def data_migrator_factory(old_xform, new_xform, **request_data):
+    migration_decisioner = migration_decisioner_factory(old_xform, new_xform,
+                                                        **request_data)
+    fields_handler = SurveyFieldsHandler(migration_decisioner)
+    data_migrator = DataMigrator(new_xform, fields_handler)
+    return data_migrator

--- a/onadata/apps/logger/data_migration/migrate_data.py
+++ b/onadata/apps/logger/data_migration/migrate_data.py
@@ -1,0 +1,63 @@
+from .surveytree import SurveyTree
+from . import backup_data
+
+
+class DataMigrator(object):
+    """
+    Adjust survey answers in database to new schema defined by updated xform.
+    Create backup of each previous survey answer.
+
+    Database can be adjusted up to user decisions. User can tell:
+    - Which new fields should be *prepopulated* with any constant value.
+      All the previous records will share common value.
+    - Can *determine* which fields are modified, and which are the new ones
+    """
+    def __init__(self, xform, fields_handler):
+        self.xform = xform
+        self.fields_handler = fields_handler
+
+    def __call__(self):
+        self.migrate()
+
+    def count_surveys(self, xform):
+        return xform.instances.all().count()
+
+    def get_surveys_iter(self, xform):
+        return xform.instances.iterator()
+
+    def migrate_survey(self, survey):
+        survey_tree = SurveyTree(survey)
+        self.fields_handler.alter_fields(survey_tree)
+        survey.xml = survey_tree.to_string()
+        survey.save()
+        survey.parsed_instance.save(async=True)
+
+    def migrate(self):
+        backup_xform = backup_data.backup_xform(self.xform)
+        for survey in self.get_surveys_iter(self.xform):
+            backup_data.backup_survey(survey, backup_xform)
+            self.migrate_survey(survey)
+
+
+class SurveyFieldsHandler(object):
+    """Handle fields operations."""
+    def __init__(self, migration_decisioner):
+        self.decisioner = migration_decisioner
+
+    def alter_fields(self, survey_tree):
+        self.add_fields(survey_tree, self.decisioner.new_fields)
+        self.remove_fields(survey_tree, self.decisioner.removed_fields)
+        self.modify_fields(survey_tree, self.decisioner.modifications)
+
+    def add_fields(self, survey_tree, new_fields):
+        for field_to_add in new_fields:
+            text = self.decisioner.get_prepopulate_text(field_to_add)
+            survey_tree.add_field(field_to_add, text)
+
+    def remove_fields(self, survey_tree, removed):
+        for field_to_remove in removed:
+            survey_tree.remove_field(field_to_remove)
+
+    def modify_fields(self, survey_tree, modifications):
+        for prev_field, new_field in modifications.iteritems():
+            survey_tree.modify_field(prev_field, new_field)

--- a/onadata/apps/logger/data_migration/surveytree.py
+++ b/onadata/apps/logger/data_migration/surveytree.py
@@ -1,0 +1,59 @@
+from lxml import etree
+
+
+class SurveyTree(object):
+    """
+    Parse XForm Instance from xml string into tree.
+    """
+    # XML elements that should not be considered as fields
+    NOT_RELEVANT = ['formhub', 'meta', 'imei']
+
+    def __init__(self, survey):
+        # Handle both cases when instance or string is passed.
+        try:
+            self.root = etree.XML(survey.xml)
+        except AttributeError:
+            self.root = etree.XML(survey)
+
+    def __repr__(self):
+        return self.to_string()
+
+    def to_string(self, pretty=True):
+        return etree.tostring(self.root, pretty_print=pretty)
+
+    def get_fields(self):
+        """Return fields as list with tree Elements."""
+        return [
+            field for field in self.root.getchildren()
+            if field.tag not in self.NOT_RELEVANT
+        ]
+
+    def get_fields_names(self):
+        """Return fields as list of string with field names."""
+        return [
+            field.tag for field in self.root.getchildren()
+            if field.tag not in self.NOT_RELEVANT
+        ]
+
+    def get_field(self, name):
+        """Get field Element by name."""
+        fields = self.get_fields()
+        for field in fields:
+            if field.tag == name:
+                return field
+
+    def create_element(self, field_name):
+        return etree.XML('<{name}></{name}>'.format(name=field_name))
+
+    def remove_field(self, field_name):
+        field = self.get_field(field_name)
+        field.getparent().remove(field)
+
+    def modify_field(self, field_name, new_tag):
+        field = self.get_field(field_name)
+        field.tag = new_tag
+
+    def add_field(self, field_name, text=''):
+        field = self.create_element(field_name)
+        field.text = text
+        self.root.append(field)

--- a/onadata/apps/logger/data_migration/views.py
+++ b/onadata/apps/logger/data_migration/views.py
@@ -1,0 +1,155 @@
+from django.db import transaction
+from django.core.urlresolvers import reverse
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.utils.translation import ugettext as _
+from django.views.decorators.http import require_POST, require_GET
+
+from onadata.apps.logger.models import XForm, create_xform_copy, copy_xform_data
+from onadata.libs.utils.log import audit_log, Actions
+from onadata.libs.utils.decorators import is_owner
+from onadata.libs.utils.logger_tools import publish_form
+from onadata.apps.main.forms import QuickConverter
+from onadata.apps.main.views import show
+from .factories import data_migrator_factory
+from .compare_xml import XFormsComparator
+
+
+@is_owner
+def pre_migration_view(request, username, id_string):
+    return render(request, 'pre_migration_view.html', {
+        'username': username,
+        'id_string': id_string,
+    })
+
+
+@require_POST
+@is_owner
+def update_xform_and_prepare_migration(request, username, id_string):
+    xform = get_object_or_404(
+        XForm, user__username=username, id_string=id_string)
+    owner = xform.user
+    old_xform = create_xform_copy(xform)
+
+    def set_form():
+        form = QuickConverter(request.POST, request.FILES)
+        form.publish(request.user, id_string)
+        audit = {'xform': xform.id_string}
+        audit_log(
+            Actions.FORM_XLS_UPDATED, request.user, owner,
+            _("XLS for '%(id_string)s' updated.") %
+            {
+                'id_string': xform.id_string,
+            }, audit, request)
+        return {
+            'type': 'alert-success',
+            'text': _(u'Successfully updated %(form_id)s.'
+                      u' Please proceed now in data migration') % {
+                            'form_id': id_string,
+                        }
+        }
+    message = publish_form(set_form)
+    messages.add_message(
+        request, messages.INFO, message['text'], extra_tags=message['type'])
+    data = {
+        'username': username,
+        'old_id_string': old_xform.id_string,
+        'new_id_string': id_string,
+    }
+    # XXX: On successful form publish (neither errors nor exceptions occurs),
+    # type of message returned by set_form() will be set to alert-success.
+    # Following code decision is based on presentation layer, however, this
+    # convention is used application-wide, and we do not have to construct try
+    # except clauses in order to catch all set_form() errors.
+    if message['type'] == 'alert-success':
+        return HttpResponseRedirect(reverse('xform-migration-gui',
+                                    kwargs=data))
+    else:
+        return abandon_xform_data_migration(request, **data)
+
+
+@require_GET
+@is_owner
+def xform_migration_gui(request, username, old_id_string, new_id_string):
+    old_xform = get_object_or_404(
+        XForm, user__username=username, id_string=old_id_string)
+    new_xform = get_object_or_404(
+        XForm, user__username=username, id_string=new_id_string)
+    xform_comparator = XFormsComparator(old_xform.xml, new_xform.xml)
+    expected_results = xform_comparator.comparison_results()
+
+    return render(request, 'migration_gui.html', {
+        'old_id_string': old_xform.id_string,
+        'new_id_string': new_xform.id_string,
+        'results': expected_results,
+        'any_results_present': any(expected_results.values()),
+    })
+
+
+@transaction.atomic
+@require_POST
+@is_owner
+def migrate_xform_data(request, username, old_id_string, new_id_string):
+    old_xform = get_object_or_404(
+        XForm, user__username=username, id_string=old_id_string)
+    new_xform = get_object_or_404(
+        XForm, user__username=username, id_string=new_id_string)
+
+    data_migrator = data_migrator_factory(old_xform, new_xform, **request.POST)
+    data_migrator.migrate()
+    old_xform.delete()  # Delete copy of form's old version
+
+    audit = {'xform': new_id_string}
+    audit_log(
+        Actions.FORM_DATA_MIGRATED, request.user, new_xform.user,
+        _("Data for '%(id_string)s' migrated") %
+        {
+            'id_string': new_id_string,
+        }, audit, request)
+
+    view_data_url = reverse('view-data', kwargs={
+        'username': username,
+        'id_string': new_id_string,
+    })
+    message_text = ('Data for %(form_id)s successfuly migrated. '
+                    '<a href="%(form_url)s">View data</a>'
+                    % {'form_id': new_xform.id_string,
+                       'form_url': view_data_url})
+    messages.add_message(request, messages.INFO, message_text,
+                         extra_tags='alert-success')
+
+    return HttpResponseRedirect(reverse(show, kwargs={
+        'username': username,
+        'id_string': new_id_string
+    }))
+
+
+@transaction.atomic
+@require_POST
+@is_owner
+def abandon_xform_data_migration(request, username, old_id_string, new_id_string):
+    old_xform = get_object_or_404(
+        XForm, user__username=username, id_string=old_id_string)
+    new_xform = get_object_or_404(
+        XForm, user__username=username, id_string=new_id_string)
+
+    # Bring back pre-migration form version and delete copy
+    copy_xform_data(from_xform=old_xform, to_xform=new_xform)
+    old_xform.delete()
+
+    view_data_url = reverse('view-data', kwargs={
+        'username': username,
+        'id_string': new_id_string,
+    })
+    message_text = ('Data migration for %(form_id)s abandoned. '
+                    '<a href="%(form_url)s">View data</a>'
+                    % {'form_id': new_xform.id_string,
+                       'form_url': view_data_url})
+    messages.add_message(request, messages.INFO, message_text,
+                         extra_tags='alert-info')
+
+    return HttpResponseRedirect(reverse(show, kwargs={
+        'username': username,
+        'id_string': new_id_string
+    }))

--- a/onadata/apps/logger/data_migration/xformtree.py
+++ b/onadata/apps/logger/data_migration/xformtree.py
@@ -1,0 +1,177 @@
+from lxml import etree
+
+
+def encode_xml_to_ascii(xml):
+    # Without proper encoding, lxml throws ValueError for Unicode string.
+    return xml.decode('utf-8').encode('ascii')
+
+
+class XFormTree(object):
+    """
+    Parse XML string into tree and operate on nodes.
+
+    Specifications of format:
+    xls forms: http://xlsform.org/
+    w3c xforms: https://www.w3.org/MarkUp/Forms/#waXForms
+    """
+    def __init__(self, xml):
+        self.root = etree.XML(encode_xml_to_ascii(xml))
+
+    def __repr__(self):
+        return self.to_string()
+
+    def to_string(self, pretty=True):
+        return etree.tostring(self.root, pretty_print=pretty)
+
+    def clean_tag(self, tag):
+        """
+        Remove w3 header that each tag contains.
+        Example: '{http://www.w3.org/1999/xhtml}head'
+        """
+        header_end = tag.find('}')
+        return tag[header_end+1:] if header_end != -1 else tag
+
+    def find_element_in_tree(self, searched_tag):
+        query = "//*[local-name()='%s']" % self.clean_tag(searched_tag)
+        try:
+            return self.root.xpath(query)[0]
+        except IndexError:
+            return None
+
+    def set_tag(self, tag_name, value):
+        el = self.find_element_in_tree(tag_name)
+        cleaned_tag = self.clean_tag(el.tag)
+        el.tag = el.tag.replace(cleaned_tag, value)
+        return el
+
+    def to_xml(self, pretty=True):
+        return etree.tostring(self.root, pretty_print=pretty)
+
+    def get_head_content(self):
+        """XML Heads content."""
+        return self.root[0][1]
+
+    def get_head_instance(self):
+        head = self.get_head_content()
+        return head[0][0]
+
+    def get_body_content(self):
+        """XML body content."""
+        return self.root[1].getchildren()
+
+    def get_title(self):
+        title = self.root[0][0]
+        return title.text
+
+    def get_fields(self):
+        """
+        Parse and return list of all fields in form.
+        Returns: list of fields.
+        """
+        instance = self.get_head_instance()
+        not_relevant = ['formhub', 'meta']
+        return [
+            self.clean_tag(field.tag) for field in instance
+            if self.clean_tag(field.tag) not in not_relevant
+        ]
+
+    def get_binds(self):
+        head = self.get_head_content()
+        # Omit <instance> with fields
+        binds = head.getchildren()[1:]
+        return binds
+
+    def get_fields_types(self):
+        """
+        Iterate xml <binds> and fetch 'type' attribute.
+        Returns dictionary: {'field_name': 'changed_type', ...}
+        """
+        binds = self.get_binds()
+        return {
+            self.get_cleaned_nodeset(bind): bind.attrib['type']
+            for bind in binds
+        }
+
+    def get_fields_obligation(self):
+        """
+        Iterate xml <binds> and fetch 'required' attribute.
+        Returns dictionary: {'field_name': 'changed_type', ...}
+        """
+        binds = self.get_binds()
+        return {
+            self.get_cleaned_nodeset(bind): self.get_obligation(bind)
+            for bind in binds
+        }
+
+    def get_obligation(self, bind):
+        try:
+            requirement = bind.attrib['required'].replace('()', '')
+        except KeyError:
+            return False
+        else:
+            return requirement == 'true'
+
+    def get_cleaned_nodeset(self, bind):
+        """
+        Extract field from bind nodeset.
+        Example input:  {'nodeset': '/Survey/name',}
+        output: 'name'
+        """
+        nodeset = bind.attrib['nodeset']
+        return nodeset[nodeset.find('/', 2)+1:]
+
+    def get_inputs_as_dict(self):
+        """
+        Get all inputs from body as dictionary
+        Output: {'input_name': <XML Elements children of input>, ...}
+        """
+        body = self.get_body_content()
+        return {
+            self.get_input_name(input): input.getchildren()
+            for input in body
+        }
+
+    def get_input_name(self, input):
+        ref = input.attrib['ref']
+        return ref[ref.find('/', 2)+1:]
+
+    def get_id_string(self):
+        return self.get_head_instance().attrib['id']
+
+    def set_id_string(self, id_string):
+        instance = self.get_head_instance()
+        instance.attrib['id'] = id_string
+        self.set_tag(instance.tag, id_string)
+
+    def added_fields(self, other_tree):
+        """Return new fields in actual tree compared to other_tree."""
+        return [
+            field for field in self.get_fields()
+            if field not in other_tree.get_fields()
+        ]
+
+    def get_select_values(self, select):
+        return [item[1].text for item in select.getchildren()[1:]]
+
+    def get_select_options(self):
+        inputs = self.get_inputs_as_dict()
+        return {
+            input_name: self.get_select_values(items[0].getparent())
+            for input_name, items in inputs.items()
+            if len(items) > 1 and self.clean_tag(items[1].tag) == 'item'
+        }
+
+    def _added_to_list(self, basic, extended):
+        """Returns items added to :basic: list"""
+        return [item for item in extended if item not in basic]
+
+    def added_select_options(self, other_tree):
+        """Return new options in actual tree compared to other_tree."""
+        actual_options = self.get_select_options()
+        other_options = other_tree.get_select_options()
+        return {
+            name: self._added_to_list(other_options[name], values)
+            for name, values in actual_options.items()
+            if name in other_options and \
+                self._added_to_list(other_options[name], values)
+        }

--- a/onadata/apps/logger/migrations/0003_auto_20170810_0837.py
+++ b/onadata/apps/logger/migrations/0003_auto_20170810_0837.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import onadata.apps.logger.models.xform
+import django.core.files.storage
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('logger', '0002_attachment_filename_length'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BackupInstance',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('xml', models.TextField()),
+                ('date_created', models.DateTimeField()),
+                ('user', models.ForeignKey(related_name='backup_surveys', to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='BackupXForm',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('xls', models.FileField(storage=django.core.files.storage.FileSystemStorage(), null=True, upload_to=onadata.apps.logger.models.xform.upload_to)),
+                ('xml', models.TextField()),
+                ('json', models.TextField(default='')),
+                ('description', models.TextField(default='', null=True)),
+                ('date_created', models.DateTimeField()),
+                ('backup_version', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(related_name='backup_xforms', to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='backupinstance',
+            name='xform',
+            field=models.ForeignKey(related_name='surveys', to='logger.BackupXForm', null=True),
+        ),
+    ]

--- a/onadata/apps/logger/models/__init__.py
+++ b/onadata/apps/logger/models/__init__.py
@@ -1,7 +1,8 @@
 from onadata.apps.logger.models.attachment import Attachment  # flake8: noqa
 from onadata.apps.logger.models.instance import Instance
 from onadata.apps.logger.models.survey_type import SurveyType
-from onadata.apps.logger.models.xform import XForm
+from onadata.apps.logger.models.xform import XForm, create_xform_copy, copy_xform_data
 from onadata.apps.logger.xform_instance_parser import InstanceParseError
 from onadata.apps.logger.models.ziggy_instance import ZiggyInstance
 from onadata.apps.logger.models.note import Note
+from onadata.apps.logger.models.backup import BackupXForm, BackupInstance

--- a/onadata/apps/logger/models/backup.py
+++ b/onadata/apps/logger/models/backup.py
@@ -1,0 +1,30 @@
+from django.db import models
+from django.core.files.storage import FileSystemStorage
+from django.contrib.auth.models import User
+
+from .xform import upload_to
+
+
+class BackupXForm(models.Model):
+    xls = models.FileField(upload_to=upload_to, null=True,
+                           storage=FileSystemStorage())
+    xml = models.TextField()
+    json = models.TextField(default=u'')
+    description = models.TextField(default=u'', null=True)
+
+    user = models.ForeignKey(User, related_name='backup_xforms', null=True)
+    date_created = models.DateTimeField()
+    backup_version = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        app_label = 'logger'
+
+
+class BackupInstance(models.Model):
+    xml = models.TextField()
+    xform = models.ForeignKey(BackupXForm, null=True, related_name='surveys')
+    date_created = models.DateTimeField()
+    user = models.ForeignKey(User, related_name='backup_surveys', null=True)
+
+    class Meta:
+        app_label = 'logger'

--- a/onadata/apps/logger/templates/migration_gui.html
+++ b/onadata/apps/logger/templates/migration_gui.html
@@ -1,0 +1,208 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block navbar %}
+{# Exclude navbar #}
+{% endblock navbar %}
+
+{% block additional-headers %}
+    <link href="{% static 'css/data_migration.css' %}" rel="stylesheet">
+{% endblock %}
+
+{% block content %}
+    <div class="migration-gui">
+        <h1>{% trans "Data migration" %}</h1>
+        <h3>{% trans "User interface" %}</h3>
+
+        <div class="bordered migration-gui__data">
+          <p><strong>
+            {% trans "Updating existing xform with submissions." %}
+          </strong></p>
+
+          {% trans "Differences between forms:" %}
+          <br>
+          {% if not any_results_present %}
+            <p> {% trans "The forms are the same. Are you sure you have picked the right file?" %}</p>
+          {% else %}
+            <ul>
+                {% if results.new_title %}
+                  <li>{% trans "Changed title:" %} {{ results.new_title }}</li>
+                {% endif %}
+
+                {% if results.fields_added %}
+                  <li>{% trans "Added fields:" %}
+                    <strong>
+                    {% for field_added in results.fields_added %}
+                      {{ field_added }} ,
+                    {% empty %}
+                      -
+                    {% endfor %}
+                    </strong>
+                  </li>
+                {% endif %}
+
+                {% if results.fields_removed %}
+                  <li>{% trans "Removed fields:" %}
+                    <strong>
+                    {% for field_removed in results.fields_removed %}
+                      {{ field_removed }} ,
+                    {% empty %}
+                      -
+                    {% endfor %}
+                    </strong>
+                  </li>
+                {% endif %}
+
+                {% if results.fields_type_diff %}
+                  <li>
+                      {% trans "Changed fields types:" %}<br>
+                      {{ results.fields_type_diff }}
+                  </li>
+                {% endif %}
+
+                {% if results.input_obligation_diff %}
+                  <li>
+                      {% trans "Changed input obligation:" %}<br>
+                      {{ results.input_obligation_diff }}
+                  </li>
+                {% endif %}
+           </ul>
+         {% endif %}
+       </div>
+      <form action="{% url "migrate-xform-data" user.username old_id_string new_id_string %}"
+            method="POST" class="form-controler">
+          {% csrf_token %}
+
+        {% if results.fields_added %}
+          <div class="fields-resolver">
+            <h4>{% trans "Determine if field is modified or new one" %}
+            </h4>
+            <p>
+              {% trans "Please match modified fields with their old correspondents or select them to be the new ones" %}
+            </p>
+              <ul>
+              {% for new_field in results.fields_added %}
+                <li>
+                  <p>{% trans "Field:" %} <strong>{{ new_field }}</strong></p>
+
+                  <select class="field-resolver" name="determine_{{ new_field }}">
+                    <option value="__new_field__">{% trans "-- new field --" %}</option>
+                    {% for replaced_field in results.fields_removed %}
+                      <option value="{{ replaced_field }}">
+                        {{ replaced_field }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </li>
+              {% endfor %}
+              </ul>
+          </div>
+
+          <div class="fields-filler">
+            <h4>{% trans "Prepopulate new fields" %}</h4>
+            {% blocktrans %}
+            <div class="fields-filler__info">
+              <p>
+                The new fields that you have just added to your survey, will now be
+                added not only to the future records, but also to all previously submitted ones.
+              </p>
+              <p>
+                Would you like to pre-populate all previous records with a particular value?
+                If so, please provide this value in the space below or leave it blank
+                if you would like these fields to be empty in previous records.
+              </p>
+            </div>
+            {% endblocktrans %}
+
+            {% for new_field in results.fields_added %}
+              <div class="fields-filler__input">
+                <label for="prepopulate_{{ new_field }}">{{ new_field }}</label>
+                <input type="text" name="prepopulate_{{ new_field }}" value="">
+              </div>
+            {% endfor %}
+            <i></i>
+          </div>
+
+        {% endif %}
+          <input type="submit" class="btn btn-success btn-controler"
+                 name="submit" value="Migrate data">
+      </form>
+
+      <form action="{% url "abandon-xform-data-migration" user.username old_id_string new_id_string %}"
+            method="POST" class="form-controler form-controler--block">
+          {% csrf_token %}
+          <input type="submit" class="btn btn-danger btn-controler"
+                 name="submit" value="Abandon migration">
+      </form>
+
+    </div>
+{% endblock %}
+{% block additional-javascript %}
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+  <script>
+    $(document).ready(function() {
+      var NEW_FIELD = '__new_field__'
+      var SELECT_PREFIX = 'determine_'
+      var PREPOPULATE_PREFIX = 'prepopulate_'
+
+      var fieldsAdded = "{{ results.fields_added|safe }}";
+      fieldsAdded = JSON.parse(fieldsAdded.replace(/'/g, '"'));
+
+      (function () {
+        for (var fieldName of fieldsAdded) {
+          var prevValue;
+
+          $('select[name="' + SELECT_PREFIX + fieldName + '"]').bind('focus', function() {
+            prevValue = this.value;
+          }).change(function() {
+            var selectName = $(this).attr('name').replace(SELECT_PREFIX, '');
+
+            if (prevValue !== NEW_FIELD) {
+              toggleOption(prevValue);
+
+              if (this.value === NEW_FIELD) {
+                togglePrepopulateField(selectName);
+              }
+            } else if (this.value !== NEW_FIELD) {
+                togglePrepopulateField(selectName);
+                toggleOption(this.value);
+            }
+            prevValue = this.value;
+          });
+        };
+      })();
+
+      function toggleOption(value) {
+        var options = $('.field-resolver option');
+        for (var option of options) {
+          if (option.value === value) {
+            $(option).toggle();
+          }
+        }
+      }
+
+      function togglePrepopulateField(name) {
+        var fields = $('.fields-filler .fields-filler__input');
+        for (field of fields) {
+          var fieldName = $(field).find('input').attr('name').replace(PREPOPULATE_PREFIX, '');
+          if (fieldName === name) {
+            $(field).toggle();
+          }
+        }
+        hidePrepopulateMessageIfAllHidden(fields);
+      }
+
+      function hidePrepopulateMessageIfAllHidden(fields) {
+        var fieldsFiller = $('.fields-filler');
+        var allHidden = true;
+        for (field of fields) {
+          if (field.style.display !== 'none') {
+            allHidden = false;
+          }
+        }
+        $(fieldsFiller).css({'display': allHidden ? 'none' : 'block'});
+      }
+    });
+  </script>
+{% endblock additional-javascript %}

--- a/onadata/apps/logger/templates/pre_migration_view.html
+++ b/onadata/apps/logger/templates/pre_migration_view.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block navbar %}
+{# Exclude navbar #}
+{% endblock navbar %}
+{% block additional-headers %}
+    <link href="{% static 'css/data_migration.css' %}" rel="stylesheet">
+{% endblock %}
+
+{% block content %}
+    <h1>Update data</h1>
+    <a tabindex="-1" href="#update-{{ id_string }}" class="confirm" role="button" data-toggle="modal">{% trans 'Update' %}</a>
+
+    <div id="xls-update-and-migrate">
+        <div id="update-{{ id_string }}" class="modal fade">
+            <form action="{% url "update-xform-and-prepare-migration" username id_string %}" method="POST" enctype="multipart/form-data">
+                {% csrf_token %}
+                <div class="modal-header">
+                    <a data-dismiss="modal" class="close">&times;</a>
+                    <h3>{% trans "Update XLS and migrate data" %}</h3>
+                    <p>{% trans "Upload xform and migrate (modify) previous survey answers according to new schema. You will be redirected to intermediary migration interface, where more details will be available." %}</p>
+                </div>
+                <div class="modal-body">
+                    <input type="file" name="xls_file" id="id_xls_file" />
+                    <input type="submit" class="btn large btn-primary" value="{% trans "Update and migrate data" %}" data-original-title="" />
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/onadata/apps/logger/tests/data_migration/fixtures/__init__.py
+++ b/onadata/apps/logger/tests/data_migration/fixtures/__init__.py
@@ -1,0 +1,2 @@
+from case1 import *
+from case2 import *

--- a/onadata/apps/logger/tests/data_migration/fixtures/case1.py
+++ b/onadata/apps/logger/tests/data_migration/fixtures/case1.py
@@ -1,0 +1,187 @@
+"""
+Example xml files to parse and compare with each other.
+
+Differences between form_xml_case_1 and form_xml_case_1_after:
+- Modify title
+- Age is decimal type
+- Location not required
+- Added new option to select in gender
+- Removed date field
+- Rename 'name' to 'last_name'
+- Add 'last_name' field
+- Add 'birthday' field
+
+XML of Surevey instance (answer to xform)
+"""
+
+FIELDS = [
+    'name', 'gender', 'photo', 'date', 'location',
+    'age', 'thanks', 'start_time', 'end_time', 'today',
+]
+
+form_xml_case_1 = '''<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Survey</h:title>
+    <model>
+      <instance>
+        <Survey id="Survey">
+          <formhub>
+            <uuid/>
+          </formhub>
+          <name/>
+          <gender/>
+          <photo/>
+          <age/>
+          <date/>
+          <location/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </Survey>
+      </instance>
+      <bind nodeset="/Survey/name" required="true()" type="string"/>
+      <bind constraint=" /Survey/age  &gt; 0 and  /Survey/age  &lt; 120" jr:constraintMsg="That's not a valid age!" nodeset="/Survey/age" required="true()" type="int"/>
+      <bind nodeset="/Survey/gender" required="true()" type="select1"/>
+      <bind nodeset="/Survey/photo" type="binary"/>
+      <bind nodeset="/Survey/date" required="true()" type="date"/>
+      <bind nodeset="/Survey/location" required="true()" type="geopoint"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/Survey/name">
+      <label>What is your name?</label>
+    </input>
+    <input ref="/Survey/age">
+      <label>How old are you?</label>
+    </input>
+    <select1 ref="/Survey/gender">
+      <label>Gender</label>
+      <item>
+        <label>Male</label>
+        <value>male</value>
+      </item>
+      <item>
+        <label>Female</label>
+        <value>female</value>
+      </item>
+    </select1>
+    <upload mediatype="image/*" ref="/Survey/photo">
+      <label>Portrait</label>
+    </upload>
+    <input ref="/Survey/date">
+      <label>Date</label>
+    </input>
+    <input ref="/Survey/location">
+      <label>Where are you?</label>
+      <hint>You need to be outside for your GPS to work.</hint>
+    </input>
+  </h:body>
+</h:html>
+'''
+
+form_xml_case_1_after = '''<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Survey2</h:title>
+    <model>
+      <instance>
+        <Survey2 id="Survey2">
+          <formhub>
+            <uuid/>
+          </formhub>
+          <first_name/>
+          <last_name/>
+          <birthday/>
+          <gender/>
+          <photo/>
+          <age/>
+          <location/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </Survey2>
+      </instance>
+      <bind nodeset="/Survey2/first_name" required="true()" type="string"/>
+      <bind nodeset="/Survey2/last_name" required="true()" type="string"/>
+      <bind nodeset="/Survey2/birthday" required="true()" type="date"/>
+      <bind constraint=" /Survey2/age  &gt; 0 and  /Survey2/age  &lt; 120" jr:constraintMsg="That's not a valid age!" nodeset="/Survey2/age" required="true()" type="decimal"/>
+      <bind nodeset="/Survey2/gender" required="true()" type="select1"/>
+      <bind nodeset="/Survey2/location" required="false()" type="geopoint"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/Survey2/name">
+      <label>What is your name?</label>
+    </input>
+    <input ref="/Survey2/age">
+      <label>How old are you?</label>
+    </input>
+    <select1 ref="/Survey2/gender">
+      <label>Gender</label>
+      <item>
+        <label>Male</label>
+        <value>male</value>
+      </item>
+      <item>
+        <label>Female</label>
+        <value>female</value>
+      </item>
+      <item>
+        <label>Unknown</label>
+        <value>unknown</value>
+      </item>
+    </select1>
+    <upload mediatype="image/*" ref="/Survey2/photo">
+      <label>Portrait</label>
+    </upload>
+    <input ref="/Survey2/location">
+      <label>Where are you?</label>
+      <hint>You need to be outside for your GPS to work.</hint>
+    </input>
+  </h:body>
+</h:html>
+'''
+
+survey_xml = '''<Survey xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="Survey">
+  <formhub>
+    <uuid>123abc</uuid>
+  </formhub>
+  <name>Alonzo Church</name>
+  <gender>male</gender>
+  <photo/>
+  <date>2000-01-01</date>
+  <location>-1 1.1 1 2</location>
+  <age>50</age>
+  <thanks/>
+  <start_time>2016-01-01T18:32:20.000+03:00</start_time>
+  <end_time>2016-01-01T18:33:03.000+03:00</end_time>
+  <today>2016-01-01</today>
+  <imei>example.com:d123das</imei>
+  <meta>
+    <instanceID>uuid:das-d123-dsa-dsa-dsa</instanceID>
+  </meta>
+</Survey>
+'''
+
+survey_after_migration = '''<Survey xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="Survey">
+  <formhub>
+    <uuid>123abc</uuid>
+  </formhub>
+  <first_name>Alonzo Church</first_name>
+  <gender>male</gender>
+  <photo/>
+  <location>-1 1.1 1 2</location>
+  <age>50</age>
+  <thanks/>
+  <start_time>2016-01-01T18:32:20.000+03:00</start_time>
+  <end_time>2016-01-01T18:33:03.000+03:00</end_time>
+  <today>2016-01-01</today>
+  <imei>example.com:d123das</imei>
+  <meta>
+    <instanceID>uuid:das-d123-dsa-dsa-dsa</instanceID>
+  </meta>
+  <last_name>Fowler</last_name>
+  <birthday></birthday>
+</Survey>
+'''

--- a/onadata/apps/logger/tests/data_migration/fixtures/case2.py
+++ b/onadata/apps/logger/tests/data_migration/fixtures/case2.py
@@ -1,0 +1,211 @@
+"""
+Second test case of example xml files to parse and compare with each other.
+
+Differences between form_xml_case_1 and form_xml_case_1_after:
+- Rename 'name' to 'your_name'
+- Add 'mood' field
+
+XML of Surevey instance (answer to xform)
+
+"""
+DEFAULT_MOOD = 'good'
+
+FIELDS_2 = [
+    'name', 'age', 'picture', 'has_children', 'gps', 'web_browsers'
+]
+
+form_xml_case_2 = '''<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>tutorial</h:title>
+    <model>
+      <instance>
+        <tutorial id="tutorial">
+          <formhub>
+            <uuid/>
+          </formhub>
+          <name/>
+          <age/>
+          <picture/>
+          <has_children/>
+          <gps/>
+          <web_browsers/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </tutorial>
+      </instance>
+      <bind nodeset="/tutorial/name" type="string"/>
+      <bind nodeset="/tutorial/age" type="int"/>
+      <bind nodeset="/tutorial/picture" type="binary"/>
+      <bind nodeset="/tutorial/has_children" type="select1"/>
+      <bind nodeset="/tutorial/gps" type="geopoint"/>
+      <bind nodeset="/tutorial/web_browsers" type="select"/>
+      <bind calculate="concat(\'uuid:\', uuid())" nodeset="/tutorial/meta/instanceID" readonly="true()" type="string"/>
+      <bind calculate="\'a842eee12a774ff5b688c7b77c5ba467\'" nodeset="/tutorial/formhub/uuid" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/tutorial/name">
+      <label>1. What is your name?</label>
+    </input>
+    <input ref="/tutorial/age">
+      <label>2. How old are you?</label>
+    </input>
+    <upload mediatype="image/*" ref="/tutorial/picture">
+      <label>3. May I take your picture?</label>
+    </upload>
+    <select1 ref="/tutorial/has_children">
+      <label>4. Do you have any children?</label>
+      <item>
+        <label>no</label>
+        <value>0</value>
+      </item>
+      <item>
+        <label>yes</label>
+        <value>1</value>
+      </item>
+    </select1>
+    <input ref="/tutorial/gps">
+      <label>5. Record your GPS coordinates.</label>
+      <hint>GPS coordinates can only be collected when outside.</hint>
+    </input>
+    <select ref="/tutorial/web_browsers">
+      <label>6. What web browsers do you use?</label>
+      <item>
+        <label>Mozilla Firefox</label>
+        <value>firefox</value>
+      </item>
+      <item>
+        <label>Google Chrome</label>
+        <value>chrome</value>
+      </item>
+      <item>
+        <label>Internet Explorer</label>
+        <value>ie</value>
+      </item>
+      <item>
+        <label>Safari</label>
+        <value>safari</value>
+      </item>
+    </select>
+  </h:body>
+</h:html>
+'''
+
+form_xml_case_2_after = '''<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>tutorial2</h:title>
+    <model>
+      <instance>
+        <tutorial2 id="tutorial2">
+          <formhub>
+            <uuid/>
+          </formhub>
+          <your_name/>
+          <age/>
+          <picture/>
+          <has_children/>
+          <gps/>
+          <web_browsers/>
+          <mood/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </tutorial2>
+      </instance>
+      <bind nodeset="/tutorial2/your_name" type="string"/>
+      <bind nodeset="/tutorial2/age" type="int"/>
+      <bind nodeset="/tutorial2/picture" type="binary"/>
+      <bind nodeset="/tutorial2/has_children" type="select1"/>
+      <bind nodeset="/tutorial2/gps" type="geopoint"/>
+      <bind nodeset="/tutorial2/web_browsers" type="select"/>
+      <bind nodeset="/tutorial2/mood" type="string"/>
+      <bind calculate="concat(\'uuid:\', uuid())" nodeset="/tutorial2/meta/instanceID" readonly="true()" type="string"/>
+      <bind calculate="\'a842eee12a774ff5b688c7b77c5ba467\'" nodeset="/tutorial2/formhub/uuid" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/tutorial2/your_name">
+      <label>1. What is your name?</label>
+    </input>
+    <input ref="/tutorial2/age">
+      <label>2. How old are you?</label>
+    </input>
+    <upload mediatype="image/*" ref="/tutorial2/picture">
+      <label>3. May I take your picture?</label>
+    </upload>
+    <select1 ref="/tutorial2/has_children">
+      <label>4. Do you have any children?</label>
+      <item>
+        <label>no</label>
+        <value>0</value>
+      </item>
+      <item>
+        <label>yes</label>
+        <value>1</value>
+      </item>
+    </select1>
+    <input ref="/tutorial2/gps">
+      <label>5. Record your GPS coordinates.</label>
+      <hint>GPS coordinates can only be collected when outside.</hint>
+    </input>
+    <select ref="/tutorial2/web_browsers">
+      <label>6. What web browsers do you use?</label>
+      <item>
+        <label>Mozilla Firefox</label>
+        <value>firefox</value>
+      </item>
+      <item>
+        <label>Google Chrome</label>
+        <value>chrome</value>
+      </item>
+      <item>
+        <label>Internet Explorer</label>
+        <value>ie</value>
+      </item>
+      <item>
+        <label>Safari</label>
+        <value>safari</value>
+      </item>
+    </select>
+    <input ref="/tutorial2/mood">
+      <label>7. How are you today?</label>
+    </input>
+  </h:body>
+</h:html>
+'''
+
+survey_xml_2 = '''<tutorial2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="tutorial2">
+  <formhub>
+    <uuid>a842eee12a774ff5b688c7b77c5ba467</uuid>
+  </formhub>
+  <name>Alfred Tarski</name>
+  <age>20</age>
+  <picture/>
+  <has_children>0</has_children>
+  <gps>0.000001 0.000001 0 0</gps>
+  <web_browsers>chrome</web_browsers>
+  <meta>
+    <instanceID>uuid:fc9eebf7-49f2-4857-b51f-bf0e385a53f5</instanceID>
+  </meta>
+</tutorial2>
+'''
+
+survey_2_after_migration = '''<tutorial2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="tutorial2">
+  <formhub>
+    <uuid>a842eee12a774ff5b688c7b77c5ba467</uuid>
+  </formhub>
+  <your_name>Alfred Tarski</your_name>
+  <age>20</age>
+  <picture/>
+  <has_children>0</has_children>
+  <gps>0.000001 0.000001 0 0</gps>
+  <web_browsers>chrome</web_browsers>
+  <meta>
+    <instanceID>uuid:fc9eebf7-49f2-4857-b51f-bf0e385a53f5</instanceID>
+  </meta>
+  <mood>good</mood>
+</tutorial2>
+'''

--- a/onadata/apps/logger/tests/data_migration/test_backup.py
+++ b/onadata/apps/logger/tests/data_migration/test_backup.py
@@ -1,0 +1,32 @@
+from onadata.apps.logger.models import Instance, XForm, BackupInstance, BackupXForm
+from onadata.apps.logger.data_migration.backup_data import backup_xform, backup_survey
+
+from .utils import MigrationTestCase
+
+
+class BackupSurveysTests(MigrationTestCase):
+    def test_backup_xform(self):
+        xform_backup = backup_xform(self.xform)
+        self.assertEqual(XForm.objects.all().count(), 2)
+        self.assertEqual(BackupXForm.objects.all().count(), 1)
+        self.assertEqual(xform_backup.xml, self.xform.xml)
+        self.assertEqual(xform_backup.user, self.xform.user)
+
+    def test_multiple_xform_backups(self):
+        for i in range(10):
+            backup_xform(self.xform)
+        self.assertEqual(BackupXForm.objects.all().count(), 10)
+
+    def test_backup_survey(self):
+        xform_backup = backup_xform(self.xform)
+        survey_backup = backup_survey(self.survey, xform_backup)
+        self.assertEqual(Instance.objects.all().count(), 1)
+        self.assertEqual(BackupInstance.objects.all().count(), 1)
+        self.assertEqual(survey_backup.xml, self.survey.xml)
+        self.assertEqual(survey_backup.user, self.survey.user)
+
+    def test_multiple_survey_backups(self):
+        xform_backup = backup_xform(self.xform)
+        for i in range(10):
+            backup_survey(self.survey, xform_backup)
+        self.assertEqual(BackupInstance.objects.all().count(), 10)

--- a/onadata/apps/logger/tests/data_migration/test_data_migration.py
+++ b/onadata/apps/logger/tests/data_migration/test_data_migration.py
@@ -1,0 +1,81 @@
+from onadata.apps.logger.models import Instance, XForm
+from onadata.apps.logger.data_migration.surveytree import SurveyTree
+from onadata.apps.logger.models.backup import BackupXForm, BackupInstance
+
+from .utils import MigrationTestCase
+from . import fixtures
+
+
+class DataMigrationUnitTests(MigrationTestCase):
+    def setUp(self):
+        super(DataMigrationUnitTests, self).setUp()
+        self.added = ['birthday', 'first_name']
+        self.potentially_removed = ['name']
+
+    def test_migrate_survey(self):
+        self.data_migrator.migrate_survey(self.survey)
+        survey_tree = SurveyTree(self.survey)
+        expected = fixtures.FIELDS[:]
+        expected.append('last_name')
+        expected.append('birthday')
+        expected.remove('date')
+        pos = expected.index('name')
+        expected[pos] = 'first_name'
+        self.assertEqual(survey_tree.get_fields_names(), expected)
+
+    def test_field_prepopulate(self):
+        self.data_migrator.migrate_survey(self.survey)
+        survey_tree = SurveyTree(self.survey)
+        last_name_field = survey_tree.get_field('last_name')
+        self.assertEqual(last_name_field.text, 'Fowler')
+
+
+class DataMigratorIntegrationTests(MigrationTestCase):
+    def test_migrator_smoke_test(self):
+        # Assure that everything won't break apart after running migrator
+        self.data_migrator.migrate()
+        self.assertEqual(XForm.objects.all().count(), 2)
+        self.assertEqual(BackupXForm.objects.all().count(), 1)
+        self.assertEqual(BackupInstance.objects.all().count(), 1)
+
+    def test_survey_migration(self):
+        self.data_migrator.migrate()
+        self.assertEqual(Instance.objects.all().count(), 1)
+        self.assertEqual(self.xform_new.instances.count(), 1)
+
+    def test_migration(self):
+        self.data_migrator.migrate()
+        self.xform_new.refresh_from_db()
+        self.assertEqualIgnoringWhitespaces(
+            self.xform_new.instances.first().xml,
+            fixtures.survey_after_migration,
+        )
+
+
+class DataMigratorIntegrationSecondTestsCase(MigrationTestCase):
+    def setUp(self):
+        self.user = self.create_user('alfred_tarski')
+        self.xform = self.create_xform(fixtures.form_xml_case_2)
+        self.xform_new = self.create_xform(fixtures.form_xml_case_2_after)
+        self.survey = self.create_survey(self.xform_new, fixtures.survey_xml_2)
+        self.setup_data_migrator(self.xform, self.xform_new)
+
+    def get_migration_decisions(self):
+        return {
+            'determine_your_name': ['name'],
+            'determine_mood': ['__new_field__'],
+            'prepopulate_mood': [fixtures.DEFAULT_MOOD],
+        }
+
+    def test_migration__second_case(self):
+        self.data_migrator.migrate()
+        self.xform.refresh_from_db()
+        self.xform_new.refresh_from_db()
+        self.assertEqualIgnoringWhitespaces(
+            self.xform_new.xml,
+            fixtures.form_xml_case_2_after,
+        )
+        self.assertEqualIgnoringWhitespaces(
+            self.xform_new.instances.first().xml,
+            fixtures.survey_2_after_migration,
+        )

--- a/onadata/apps/logger/tests/data_migration/test_decisioner.py
+++ b/onadata/apps/logger/tests/data_migration/test_decisioner.py
@@ -1,0 +1,59 @@
+from onadata.apps.logger.data_migration.factories import migration_decisioner_factory
+
+from .utils import MigrationTestCase
+
+
+class MigrationDecisionerUnitTests(MigrationTestCase):
+    def setUp(self):
+        super(MigrationDecisionerUnitTests, self).setUp()
+        self.added = ['birthday', 'first_name']
+        self.potentially_removed = ['name']
+        self.migration_decisioner = migration_decisioner_factory(
+            self.xform, self.xform_new, **self.migration_decisions)
+
+    def test_extract_migration_decisions(self):
+        data = {
+            'some': 'not',
+            'relevant': 'data',
+        }
+        data.update(self.migration_decisions)
+        expected = {
+            key: value[0]
+            for key, value in self.migration_decisions.iteritems()
+        }
+        self.assertEqual(
+            self.migration_decisioner._extract_migration_decisions(**data),
+            expected
+        )
+
+    def test_get_removed_fields(self):
+        self.assertEqual(
+            self.migration_decisioner.get_removed_fields(
+                self.potentially_removed),
+            [],
+        )
+
+    def test_get_fields_modifications(self):
+        self.assertEqual(
+            self.migration_decisioner.get_fields_modifications(
+                self.potentially_removed),
+            {'name': 'first_name'},
+        )
+
+    def test_get_new_fields(self):
+        self.assertEqual(
+            self.migration_decisioner.get_new_fields(self.added),
+            ['birthday'],
+        )
+
+    def test_get_prepopulate_text(self):
+        self.assertEqual(
+            self.migration_decisioner.get_prepopulate_text('last_name'),
+            'Fowler',
+        )
+
+    def test_get_determined_field(self):
+        self.assertEqual(
+            self.migration_decisioner._get_determined_field('birthday'),
+            self.migration_decisioner.NEW_FIELD,
+        )

--- a/onadata/apps/logger/tests/data_migration/test_views.py
+++ b/onadata/apps/logger/tests/data_migration/test_views.py
@@ -1,0 +1,76 @@
+from onadata.apps.logger.models import Instance, XForm
+from django.test import Client
+from django.core.urlresolvers import reverse
+
+from .utils import MigrationTestCase
+
+
+class MigrationViewsTests(MigrationTestCase):
+    def setUp(self):
+        super(MigrationViewsTests, self).setUp()
+        self.client = Client()
+        self.client.login(username=self.user.username,
+                          password='password')
+
+    def get_data(self):
+        return {
+            'username': self.user.username,
+            'old_id_string': self.xform.id_string,
+            'new_id_string': self.xform_new.id_string,
+        }
+
+    def test_xform_migration_gui(self):
+        url = reverse('xform-migration-gui', kwargs=self.get_data())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.xform_new.id_string, response.content)
+        self.assertIn('Data migration', response.content)
+        self.assertIn('birthday', response.content)
+
+    def test_abandon_xform_data_migration(self):
+        url = reverse('abandon-xform-data-migration', kwargs=self.get_data())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(XForm.objects.count(), 1)
+        self.assertEqual(self.xform_new.instances.count(), 1)
+        self.assertEqual(Instance.objects.count(), 1)
+
+    def test_abandon_xform_data_migration_other_user(self):
+        user2 = self.create_user('user2')
+        self.client.login(username=user2.username,
+                          password='password')
+        url = reverse('abandon-xform-data-migration', kwargs=self.get_data())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(XForm.objects.count(), 2)
+
+    def test_migrate_xform_data(self):
+        url = reverse('migrate-xform-data', kwargs=self.get_data())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(XForm.objects.count(), 1)
+        self.assertEqual(Instance.objects.count(), 1)
+
+    def test_update_xform_and_prepare_migration(self):
+        data = {
+            'username': self.user.username,
+            'id_string': self.xform_new.id_string,
+        }
+        url = reverse('update-xform-and-prepare-migration', kwargs=data)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(XForm.objects.count(), 2)
+        self.assertEqual(Instance.objects.count(), 1)
+
+    def test_migration_process(self):
+        initial_data = {
+            'username': self.user.username,
+            'id_string': self.xform.id_string,
+        }
+        url = reverse('update-xform-and-prepare-migration', kwargs=initial_data)
+        self.client.post(url)
+        url = reverse('migrate-xform-data', kwargs=self.get_data())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code,  302)
+        self.assertEqual(XForm.objects.count(), 1)
+        self.assertEqual(Instance.objects.count(), 1)

--- a/onadata/apps/logger/tests/data_migration/test_xml_compare.py
+++ b/onadata/apps/logger/tests/data_migration/test_xml_compare.py
@@ -1,0 +1,75 @@
+from django.test import TestCase
+
+from onadata.apps.logger.data_migration.compare_xml import XFormsComparator
+
+from . import fixtures
+
+
+class CompareXMLTestCase(TestCase):
+    def setUp(self):
+        self.RealComparator = XFormsComparator(fixtures.form_xml_case_1,
+                                               fixtures.form_xml_case_1_after)
+        # Used when no rational data is needed
+        self.DummyComparator = XFormsComparator('<a></a>', '<b></b>')
+        self.added_fields = ['first_name', 'last_name', 'birthday']
+        self.removed_fields = ['name', 'date']
+
+    def clean_tag(self, tag):
+        return self.DummyComparator.clean_tag(tag)
+
+    def test_clean_tag(self):
+        header = '{http://www.w3.org/1999/xhtml}title'
+        result = self.DummyComparator.clean_tag(header)
+        self.assertEqual(result, 'title')
+
+        result = self.DummyComparator.clean_tag('title')
+        self.assertEqual(result, 'title')
+
+    def test_titles_diff(self):
+        self.assertEqual(self.RealComparator.titles_diff(), 'Survey2')
+
+    def test_fields_diff(self):
+        self.assertEqual(
+            self.RealComparator.fields_diff(),
+            (self.added_fields, self.removed_fields))
+
+    def test_fields_type_diff(self):
+        self.assertEqual(
+            self.RealComparator.fields_type_diff(), {'age': 'decimal'}
+        )
+
+    def test_input_obligation_diff(self):
+        self.assertEqual(
+            self.RealComparator.input_obligation_diff(), {'location': False}
+        )
+
+    def test_pprint_dict(self):
+        self.assertEqual(
+            self.DummyComparator.pprint_dict(**{'abc': 123}),
+            'Name: abc, new value: 123\n',
+        )
+
+    def test_sanity_check_comparison_results(self):
+        self.assertEqual(
+            self.RealComparator.titles_diff(),
+            self.RealComparator.comparison_results()['new_title'],
+        )
+
+    def test_comparison_result(self):
+        expected_result = {
+            'new_title': 'Survey2',
+            'fields_added': self.added_fields,
+            'fields_removed': self.removed_fields,
+            'input_obligation_diff': 'Name: location, new value: False\n',
+            'fields_type_diff': 'Name: age, new value: decimal\n',
+        }
+        self.assertEqual(
+            self.RealComparator.comparison_results(),
+            expected_result,
+        )
+
+    def test_select_diff(self):
+        self.assertEqual(
+            self.RealComparator.selects_diff(),
+            ({'gender': ['unknown']}, {}),
+        )

--- a/onadata/apps/logger/tests/data_migration/test_xmltrees.py
+++ b/onadata/apps/logger/tests/data_migration/test_xmltrees.py
@@ -1,0 +1,134 @@
+from lxml import etree
+
+from django.test import TestCase
+
+from onadata.apps.logger.data_migration.xformtree import XFormTree
+from onadata.apps.logger.data_migration.surveytree import SurveyTree
+
+from . import fixtures
+
+
+class XFormTreeOperationsTestCase(TestCase):
+    def setUp(self):
+        self.prev_tree = XFormTree(fixtures.form_xml_case_1)
+        self.new_tree = XFormTree(fixtures.form_xml_case_1_after)
+
+    def test_create_tree(self):
+        self.assertTrue(etree.iselement(self.prev_tree.root))
+        self.assertTrue(etree.iselement(self.new_tree.root))
+        self.assertEqual(self.prev_tree.clean_tag(self.prev_tree.root.tag), 'html')
+
+    def test_get_titles(self):
+        self.assertEqual(
+            (self.prev_tree.get_title(), self.new_tree.get_title()),
+            ('Survey', 'Survey2'))
+
+    def test_get_heads_instance(self):
+        self.assertEqual(
+            self.prev_tree.clean_tag(
+                self.prev_tree.get_head_instance().tag), 'Survey'
+        )
+
+    def test_get_fields(self):
+        expected1 = ['name',  'gender',  'photo',  'age',  'date',  'location']
+        expected2 = [
+            'first_name', 'last_name', 'birthday',
+            'gender',  'photo',  'age',  'location'
+        ]
+        self.assertEqual(
+            (self.prev_tree.get_fields(), self.new_tree.get_fields()),
+            (expected1, expected2)
+        )
+
+    def test_get_fields_types(self):
+        self.assertDictContainsSubset(
+            {'name': 'string', 'location': 'geopoint'},
+            self.prev_tree.get_fields_types()
+        )
+
+    def test_get_inputs_as_dict(self):
+        self.assertDictContainsSubset(
+            {'name': self.prev_tree.get_body_content()[0].getchildren()},
+            self.prev_tree.get_inputs_as_dict()
+        )
+
+    def test_get_cleaned_nodeset(self):
+        self.assertEqual(
+            self.prev_tree.get_cleaned_nodeset(
+                self.prev_tree.get_binds()[0]), 'name'
+        )
+
+    def test_get_input_name(self):
+        self.assertEqual(
+            self.prev_tree.get_input_name(
+                self.prev_tree.get_body_content()[0]), 'name',
+        )
+
+    def test_find_element_in_tree(self):
+        searched_tag = self.prev_tree.get_head_instance().tag
+        element = self.prev_tree.find_element_in_tree(searched_tag)
+        self.assertTrue(etree.iselement(element))
+        self.assertEqual(element.tag, searched_tag)
+
+    def test_find_element_in_tree_by_cleaned_tag(self):
+        searched_tag = 'gender'
+        element = self.prev_tree.find_element_in_tree(searched_tag)
+        self.assertTrue(etree.iselement(element))
+        self.assertEqual(self.prev_tree.clean_tag(element.tag), searched_tag)
+
+    def test_not_finding_element_in_tree(self):
+        element = self.prev_tree.find_element_in_tree('definitely_not_here')
+        self.assertEqual(element, None)
+
+    def test_to_string(self):
+        self.assertTrue(self.prev_tree.to_string())
+
+    def test_set_tag(self):
+        tag_name = self.prev_tree.get_head_instance().tag
+        new_tag_name = 'Survey2'
+        self.prev_tree.set_tag(tag_name, new_tag_name)
+        self.assertEqual(
+            self.prev_tree.clean_tag(self.prev_tree.get_head_instance().tag),
+            new_tag_name
+        )
+
+
+class SurveyTreeOperationsTest(TestCase):
+    def setUp(self):
+        self.survey = SurveyTree(fixtures.survey_xml)
+
+    def test_get_fields_names(self):
+        self.assertEqual(
+            self.survey.get_fields_names(),
+            fixtures.FIELDS
+        )
+
+    def test_get_fields(self):
+        for field in self.survey.get_fields():
+            self.assertTrue(etree.iselement(field))
+
+    def test_get_field(self):
+        self.assertTrue(etree.iselement(self.survey.get_field('name')))
+        self.assertTrue(etree.iselement(self.survey.get_field('photo')))
+
+    def test_create_element(self):
+        self.assertTrue(etree.iselement(self.survey.create_element('name')))
+
+    def test_remove_field(self):
+        expected = fixtures.FIELDS[:]
+        expected.remove('name')
+        self.survey.remove_field('name')
+        self.assertEqual(self.survey.get_fields_names(), expected)
+
+    def test_modify_field(self):
+        expected = fixtures.FIELDS[:]
+        pos = expected.index('name')
+        expected[pos] = 'first_name'
+        self.survey.modify_field('name', 'first_name')
+        self.assertEqual(self.survey.get_fields_names(), expected)
+
+    def test_add_field(self):
+        expected = fixtures.FIELDS[:]
+        expected.append('opinion')
+        self.survey.add_field('opinion')
+        self.assertEqual(self.survey.get_fields_names(), expected)

--- a/onadata/apps/logger/tests/data_migration/utils.py
+++ b/onadata/apps/logger/tests/data_migration/utils.py
@@ -1,0 +1,59 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from onadata.apps.logger.models import Instance, XForm
+from onadata.apps.viewer.models import ParsedInstance
+from onadata.apps.logger.data_migration.factories import data_migrator_factory
+
+from . import fixtures
+
+
+def remove_whitespaces(string):
+    return string.replace('\n', '').replace(' ', '')
+
+
+class MigrationTestCase(TestCase):
+    def setUp(self):
+        self.user = self.create_user('johnny_cash')
+        self.xform = self.create_xform(fixtures.form_xml_case_1)
+        self.xform_new = self.create_xform(fixtures.form_xml_case_1_after)
+        self.survey = self.create_survey(self.xform_new)
+        self.setup_data_migrator(self.xform, self.xform_new)
+
+    def create_user(self, username):
+        return User.objects.create_user(username=username,
+                                        password='password')
+
+    def create_xform(self, xml):
+        return XForm.objects.create(
+            xml=xml,
+            user=self.user
+        )
+
+    def create_survey(self, xform, xml=fixtures.survey_xml):
+        survey = Instance.objects.create(
+            xml=xml,
+            user=self.user,
+            xform=xform)
+        survey.parsed_instance = ParsedInstance.objects.create(
+            instance=survey)
+        return survey
+
+    def setup_data_migrator(self, xform, xform_new):
+        self.migration_decisions = self.get_migration_decisions()
+        self.data_migrator = data_migrator_factory(xform, xform_new,
+                                                   **self.migration_decisions)
+
+    def get_migration_decisions(self):
+        return {
+            'prepopulate_last_name': ['Fowler'],
+            'determine_first_name': ['name'],
+            'determine_birthday': ['__new_field__'],
+            'determine_last_name': ['__new_field__'],
+        }
+
+    def assertEqualIgnoringWhitespaces(self, result, expected):
+        self.assertEqual(
+            remove_whitespaces(result),
+            remove_whitespaces(expected),
+        )

--- a/onadata/apps/logger/urls.py
+++ b/onadata/apps/logger/urls.py
@@ -1,0 +1,21 @@
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns(
+    '',
+    url(r'(?P<old_id_string>[^/]+)/(?P<new_id_string>[^/]+)/update-and-migrate$',
+        'onadata.apps.logger.data_migration.views.xform_migration_gui',
+        name='xform-migration-gui'),
+    url(r'(?P<id_string>[^/]+)/migrate-view$',
+        'onadata.apps.logger.data_migration.views.pre_migration_view',
+        name='pre-migration-view'),
+    url(r'(?P<id_string>[^/]+)/update-and-migrate$',
+        'onadata.apps.logger.data_migration.views.update_xform_and_prepare_migration',
+        name='update-xform-and-prepare-migration'),
+    url(r'(?P<old_id_string>[^/]+)/(?P<new_id_string>[^/]+)/migrate-data$',
+        'onadata.apps.logger.data_migration.views.migrate_xform_data',
+        name='migrate-xform-data'),
+    url(r'(?P<old_id_string>[^/]+)/(?P<new_id_string>[^/]+)/abandon-migration$',
+        'onadata.apps.logger.data_migration.views.abandon_xform_data_migration',
+        name='abandon-xform-data-migration'),
+)

--- a/onadata/apps/main/templates/show.html
+++ b/onadata/apps/main/templates/show.html
@@ -270,7 +270,7 @@
                   <a data-toggle="modal" data-target="#popupmodal" class="showqr btn btn-info" href="{% url "get_qrcode" xform.user.username xform.id_string %}"><i class="icon-tablet"></i> {% trans "Mobile" %}</a>
                   {% endif %}
                   {% if can_edit or xform.shared %}
-                  <a class="btn btn-info" rel="tooltip" title="{% trans 'Preview Form' %}" href="#preview-modal"
+                  <a classV="btn btn-info" rel="tooltip" title="{% trans 'Preview Form' %}" href="#preview-modal"
                      data-toggle="modal">
                       <i class="icon-check icon-white"></i> {% trans "Preview Form" %}
                   </a>

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -173,7 +173,7 @@ urlpatterns = patterns(
     url(r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/edit-data/(?P<data_id>"
         "\d+)$", 'onadata.apps.logger.views.edit_data', name='edit_data'),
     url(r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/view-data",
-        'onadata.apps.viewer.views.data_view'),
+        'onadata.apps.viewer.views.data_view', name='view-data'),
     url(r"^(?P<username>\w+)/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"
         "/new$", 'onadata.apps.viewer.views.create_export'),
     url(r"^(?P<username>\w+)/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"
@@ -190,6 +190,8 @@ urlpatterns = patterns(
     url(r'^(?P<username>\w+)/exports/', include('onadata.apps.export.urls')),
 
     url(r'^(?P<username>\w+)/reports/', include('onadata.apps.survey_report.urls')),
+
+    url(r'^(?P<username>[^/]+)/forms/', include('onadata.apps.logger.urls')),
 
     # odk data urls
     url(r"^submission$",

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -421,7 +421,7 @@ def show(request, username=None, id_string=None, uuid=None):
 
     return render(request, "show.html", data)
 
-# SETTINGS SCREEN FOR KPI, LOADED IN IFRAME 
+# SETTINGS SCREEN FOR KPI, LOADED IN IFRAME
 @require_GET
 def show_form_settings(request, username=None, id_string=None, uuid=None):
     if uuid:
@@ -797,8 +797,8 @@ def edit(request, username, id_string):
         if request.is_ajax():
             return HttpResponse(_(u'Updated succeeded.'))
         else:
-            if 'HTTP_REFERER' in request.META and request.META['HTTP_REFERER'].strip(): 
-                return HttpResponseRedirect(request.META['HTTP_REFERER'])               
+            if 'HTTP_REFERER' in request.META and request.META['HTTP_REFERER'].strip():
+                return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
             return HttpResponseRedirect(reverse(show, kwargs={
                 'username': username,
@@ -1010,8 +1010,8 @@ def download_media_data(request, username, id_string, data_id):
                         'id_string': xform.id_string,
                         'filename': os.path.basename(data.data_file.name)
                     }, audit, request)
-                if 'HTTP_REFERER' in request.META and request.META['HTTP_REFERER'].strip(): 
-                    return HttpResponseRedirect(request.META['HTTP_REFERER'])               
+                if 'HTTP_REFERER' in request.META and request.META['HTTP_REFERER'].strip():
+                    return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
                 return HttpResponseRedirect(reverse(show, kwargs={
                     'username': username,
@@ -1190,8 +1190,8 @@ def set_perm(request, username, id_string):
         return HttpResponse(
             json.dumps(
                 {'status': 'success'}), content_type='application/json')
-    if 'HTTP_REFERER' in request.META and request.META['HTTP_REFERER'].strip(): 
-        return HttpResponseRedirect(request.META['HTTP_REFERER'])               
+    if 'HTTP_REFERER' in request.META and request.META['HTTP_REFERER'].strip():
+        return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
     return HttpResponseRedirect(reverse(show, kwargs={
         'username': username,

--- a/onadata/apps/viewer/migrations/0003_auto_20170803_1219.py
+++ b/onadata/apps/viewer/migrations/0003_auto_20170803_1219.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('viewer', '0002_auto_20160205_1915'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='export',
+            name='export_type',
+            field=models.CharField(default=b'xls', max_length=10, choices=[(b'xls', b'Excel'), (b'csv', b'CSV'), (b'gdoc', b'GDOC'), (b'zip', b'ZIP'), (b'kml', b'kml'), (b'csv_zip', b'CSV ZIP'), (b'sav_zip', b'SAV ZIP'), (b'sav', b'SAV'), (b'external', b'Excel'), (b'analyser', b'Analyser')]),
+        ),
+    ]

--- a/onadata/libs/templates/base.html
+++ b/onadata/libs/templates/base.html
@@ -51,7 +51,9 @@
     {% else %}
 
     <body class='authenticated'>
-		{% include "topbar.html"%}
+    {% block navbar %}
+  		{% include "topbar.html"%}
+    {% endblock navbar %}
 
     {% endif %}
 

--- a/onadata/libs/utils/log.py
+++ b/onadata/libs/utils/log.py
@@ -39,6 +39,7 @@ Actions = Enum(
     FORM_ENTER_DATA_REQUESTED="form-enter-data-requested",
     FORM_MAP_VIEWED="form-map-viewed",
     FORM_DATA_VIEWED="form-data-viewed",
+    FORM_DATA_MIGRATED="form-data-migrated",
     EXPORT_CREATED="export-created",
     EXPORT_DOWNLOADED="export-downloaded",
     EXPORT_DELETED="export-deleted",


### PR DESCRIPTION
Right now, while having a form with submissions, you can't modify the column name without data loss - variable renaming input available in KPI does not really rename a variable in submissions, but create a new field in xml with given name. That said, it does not migrate the data to the new variable new, which result in losing the data in all of the previous records!

In our scenarios, while using kobotoolbox, renaming the existing variables turned out to be quite common case, or at least as common, as we couldn't afford manual data migration.

The tool that is present in this patch is doing exactly what is missing, so after renaming a variable, it migrates all of the submissions XML to the newly set name. What's more, in case of adding a new field, you have a possibility to set a default value in all of the previous submissions. Before doing the migration, we back up all of the data, so that later on we might want to introduce a "Revert migration" button, in case user did something mistakenly / just want to go back to previous state.

The patch was written according to O rule from SOLID, it neither tries to modify existing code (with necessary exceptions) nor change its behaviour, but just provide an extension. It was confirmed to work as expected on test data.

Right now, the data migration is only supported in legacy view, using XLS Forms upload. Nevertheless, it is written in a generic way, so that (maybe with slight modifications) the data could also come from React layer, we would just need to rewrite migration gui into material design components.

Pre-migration view can be accessed on `/<username>/<form_id_string>/migrate-view`. Ideally, it should be a button in a form detail view, however, i approached a "wall" here:

As i can see, on the view presnt on `/<username>/<form_id_string>/` url in kobocat legacy mode, so the most basic form detail view, everything that is displayed in "onadata.apps.main.views.show()" function, is wrapped in a mysterious "kc-hide" css class that set display to none, and some other view is rendered. Where can i find code base for that new view? I can't find it neither in kobocat nor in kpi. Am i missing something, or is it in other repository? If you could point me to that, i could add a "Update XLS Form" button (if not here, on the upstream, i would like to use it just in our fork)

UI screenshots:
https://www.dropbox.com/sh/2g3zguhdspacdl2/AAARsuoyqXILIpuZLX3bB9OBa?dl=0

XForm changes reflected in the scenario presented on screenshots:
- Rename 'name' to 'your_name'
- Add 'mood' field
- Set 'mood' default value for old surveys to 'good' 
