### PR TITLE
Require Pyxform with namespaces support

### DIFF
--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -20,7 +20,7 @@ pymongo==2.7.2
 lxml==3.4.0
 #-e git+https://github.com/onaio/pyxform.git@onaio#egg=pyxform
 # kobo fork supports csvs with utf, character escaping, etc.
--e git+https://github.com/kobotoolbox/pyxform.git#egg=pyxform-dev
+-e git+https://github.com/kobotoolbox/pyxform.git@2.017.36#egg=pyxform
 django-reversion==2.0.8
 xlrd==0.9.3
 xlwt==0.7.5


### PR DESCRIPTION
See kobotoolbox/tasks#137

Deploying this now to https://kc.du.kbtdev.org/ for testing