### PR TITLE
Slow count queries

### DIFF
--- a/onadata/apps/logger/migrations/0003_add-index-on-attachment-media-file.py
+++ b/onadata/apps/logger/migrations/0003_add-index-on-attachment-media-file.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import onadata.apps.logger.models.attachment
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('logger', '0002_attachment_filename_length'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='attachment',
+            name='media_file',
+            field=models.FileField(max_length=380, upload_to=onadata.apps.logger.models.attachment.upload_to, db_index=True),
+        ),
+    ]

--- a/onadata/apps/logger/migrations/0004_increase-length-of-attachment-mimetype-field.py
+++ b/onadata/apps/logger/migrations/0004_increase-length-of-attachment-mimetype-field.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('logger', '0003_add-index-on-attachment-media-file'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='attachment',
+            name='mimetype',
+            field=models.CharField(default=b'', max_length=100, blank=True),
+        ),
+    ]

--- a/onadata/apps/logger/models/attachment.py
+++ b/onadata/apps/logger/models/attachment.py
@@ -20,9 +20,9 @@ def upload_to(attachment, filename):
 
 class Attachment(models.Model):
     instance = models.ForeignKey(Instance, related_name="attachments")
-    media_file = models.FileField(upload_to=upload_to, max_length=380)
+    media_file = models.FileField(upload_to=upload_to, max_length=380, db_index=True)
     mimetype = models.CharField(
-        max_length=50, null=False, blank=True, default='')
+        max_length=100, null=False, blank=True, default='')
 
     class Meta:
         app_label = 'logger'

--- a/onadata/apps/viewer/views.py
+++ b/onadata/apps/viewer/views.py
@@ -741,20 +741,23 @@ def attachment_url(request, size='medium'):
         else:
             # search for media_file with exact matching name
             result = Attachment.objects.filter(media_file=media_file)[0:1]
-    if result.count() == 0:
-        media_file_logger.info('attachment not found')
-        return HttpResponseNotFound(_(u'Attachment not found'))
-    attachment = result[0]
-    if not attachment.mimetype.startswith('image'):
-        return redirect(attachment.media_file.url)
 
-    try:
-        media_url = image_url(attachment, size)
-    except:
-        media_file_logger.error('could not get thumbnail for image', exc_info=True)
-    else:
-        if media_url:
-            return redirect(media_url)
+        if len(result) == 0:
+            media_file_logger.info('attachment not found')
+            return HttpResponseNotFound(_(u'Attachment not found'))
+
+        attachment = result[0]
+
+        if not attachment.mimetype.startswith('image'):
+            return redirect(attachment.media_file.url)
+
+        try:
+            media_url = image_url(attachment, size)
+        except:
+            media_file_logger.error('could not get thumbnail for image', exc_info=True)
+        else:
+            if media_url:
+                return redirect(media_url)
 
     return HttpResponseNotFound(_(u'Error: Attachment not found'))
 


### PR DESCRIPTION
According to this bug: https://github.com/kobotoolbox/tasks/issues/153, I've added an index on `media_file` field in table `Attachment` and increased `mime_type` field up to 100 characters.

In the Python code, there was a possibilty that `result` could be reached without being initialized.
I've indented the code below first `if` to avoid `result` variable to be undefined whenever `if`returns `false`.
When `result` is set, it's a list of `Assignment` objects, so instead of calling `result.count()` - which is a call to database -, I've changed the calculation with `len` method for python lists.
