### PR TITLE
DRF==3.6.4, added explicit fields for some ModelSerializers - fixes #397

### DIFF
--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -29,6 +29,7 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = MetaData
+        fields = '__all__'
 
     # was previously validate_data_value but the signature change in DRF3.
     def validate(self, attrs):
@@ -61,4 +62,3 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
             data_file=data_file,
             data_file_type=data_file_type
         )
-

--- a/onadata/libs/serializers/note_serializer.py
+++ b/onadata/libs/serializers/note_serializer.py
@@ -12,6 +12,7 @@ class NoteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Note
+        fields = '__all__'
 
     def save(self, user=None):
         # This used to be in note_viewset

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -50,15 +50,15 @@ path.py==8.1.2
 dict2xml==1.3
 
 # api support
-djangorestframework==3.3.2
-djangorestframework-csv==1.4.1
+djangorestframework==3.6.4
+djangorestframework-csv==2.0.0
 djangorestframework-jsonp==1.0.2
 djangorestframework-xml==1.3.0
 
 # cors
 django-cors-headers==0.13
 Markdown==2.5
-django-filter==0.7
+django-filter==1.1.0
 
 # captcha
 recaptcha-client==1.0.6


### PR DESCRIPTION
Django REST Framework 3.6 contains some fixes, for example using a `source` parameter with a Serializer e.g. `serializers.CharField(source='json.username', default=None, allow_null=True)` fails gracefully with DRF 3.6 while it raises an exception with DRF 3.3.2.
It is necessary to explicitly add `fields = '__all__'` to `ModelSerializer` instances that neither set `fields` or `exclude`, but as far as I can tell that only applied to `NoteSerializer` and `MetaDataSerializer`.