### PR TITLE
Periodically clean up KC temporary files & remove auto-created migrations.

### DIFF
--- a/docker/cron/clean_up_tmp
+++ b/docker/cron/clean_up_tmp
@@ -1,0 +1,1 @@
+50 * * * * root find /tmp/ -mmin +60 -print -delete >/dev/null 2>&1

--- a/docker/init.bash
+++ b/docker/init.bash
@@ -12,8 +12,13 @@ echo 'Synchronizing database.'
 python manage.py syncdb --noinput
 
 echo 'Running migrations.'
-python manage.py makemigrations
+# python manage.py makemigrations
 python manage.py migrate --noinput
+
+
+rm -f /etc/cron.d/clean_up_tmp
+cp docker/cron/clean_up_tmp /etc/cron.d/
+echo 'KoBoCat tmp clean-up cron installed'
 
 rm -f /etc/cron.d/backup_media_crontab
 if [[ -z "${KOBOCAT_MEDIA_BACKUP_SCHEDULE}" ]]; then


### PR DESCRIPTION
According to https://github.com/kobotoolbox/kobo-docker/issues/149 issue found in kobo-docker repository. 
As already discussed, I've also commented auto-created migrations command in init.bash