### PR TITLE
Configurable default for `UserProfile.require_auth`

### DIFF
--- a/onadata/apps/main/models/user_profile.py
+++ b/onadata/apps/main/models/user_profile.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.signals import post_save
@@ -77,3 +78,14 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
                 assign_perm(perm.codename, instance.created_by, instance)
 post_save.connect(set_object_permissions, sender=UserProfile,
                   dispatch_uid='set_object_permissions')
+
+
+def default_user_profile_require_auth(
+        sender, instance, created, raw, **kwargs):
+    if raw or not created:
+        return
+    instance.require_auth = \
+        settings.REQUIRE_AUTHENTICATION_TO_SEE_FORMS_AND_SUBMIT_DATA_DEFAULT
+    instance.save()
+post_save.connect(default_user_profile_require_auth, sender=UserProfile,
+                      dispatch_uid='default_user_profile_require_auth')

--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -145,6 +145,11 @@ if EMAIL_BACKEND == 'django.core.mail.backends.filebased.EmailBackend':
     if not os.path.isdir(EMAIL_FILE_PATH):
         os.mkdir(EMAIL_FILE_PATH)
 
+# Default value for the `UserProfile.require_auth` attribute
+REQUIRE_AUTHENTICATION_TO_SEE_FORMS_AND_SUBMIT_DATA_DEFAULT = os.environ.get(
+        'REQUIRE_AUTHENTICATION_TO_SEE_FORMS_AND_SUBMIT_DATA_DEFAULT',
+        'False') == 'True'
+
 # Optional Sentry configuration: if desired, be sure to install Raven and set
 # RAVEN_DSN in the environment
 if 'RAVEN_DSN' in os.environ:


### PR DESCRIPTION
...which appears in the UI as "Require authentication to see forms and
submit data". This affects *NEW USERS* only! To change existing users, use the
Django shell and follow the example below:
```
    kobocat$ ./manage.py shell
    (InteractiveConsole)
    >>> from onadata.apps.main.models import UserProfile
    >>> updated_count = UserProfile.objects.update(require_auth=True)
    >>> updated_count
    6
```
Closes #335