### PR TITLE
Remove `encode()` to fix non-ASCII XML hashing

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -330,7 +330,7 @@ class Instance(models.Model):
         :return: The resulting hash.
         :rtype: str
         '''
-        return sha256(input_string.encode('UTF-8')).hexdigest()
+        return sha256(input_string).hexdigest()
 
     @property
     def point(self):


### PR DESCRIPTION
Fixes #401. Thanks to @jeverling for reporting the problem. 