### PR TITLE
KOBOCAT_ROOT_URI_PREFIX in instance.js for correct API URL - fixes #405

### DIFF
--- a/onadata/apps/main/context_processors.py
+++ b/onadata/apps/main/context_processors.py
@@ -23,6 +23,7 @@ def site_name(request):
         site_name = site.name
     return {'SITE_NAME': site_name}
 
+
 def base_url(request):
     """
     Return a BASE_URL template context for the current request.
@@ -31,5 +32,11 @@ def base_url(request):
         scheme = 'https://'
     else:
         scheme = 'http://'
-        
-    return {'BASE_URL': scheme + request.get_host(),}
+
+    return {'BASE_URL': scheme + request.get_host(), }
+
+
+def kobocat_root_uri_prefix(request):
+    # settings.KOBOCAT_ROOT_URI_PREFIX will have trailing and leading slashes, so we fall back to a
+    # single (leading) slash when it isn't set
+    return {'KOBOCAT_ROOT_URI_PREFIX': getattr(settings, 'KOBOCAT_ROOT_URI_PREFIX', '/')}

--- a/onadata/apps/viewer/static/js/instance.js
+++ b/onadata/apps/viewer/static/js/instance.js
@@ -57,7 +57,9 @@ function addOrEditNote(){
         if (note == ""){
             return false;
         }
-        var notes_url = '/api/v1/notes',
+        // KOBOCAT_ROOT_URI_PREFIX variable will be set in the template using a context processor, in case kobocat
+        // is running under a URL path prefix (e.g. /kobocat/). In case the variable isn't set it will use /
+        var notes_url = ('KOBOCAT_ROOT_URI_PREFIX' in window ? KOBOCAT_ROOT_URI_PREFIX : '/') + 'api/v1/notes',
             post_data = {'note': note, 'instance': instance_id};
         if($("#notesform #note-id").val() != undefined){
             // Edit Note
@@ -442,7 +444,7 @@ function deleteNote(obj){
     var note_id = $(obj).data('note-id');
     if(confirm("Are you sure you want to delete \"" + note + "\"?") == true){
         $.ajax({
-            url: "/api/v1/notes/" + note_id,
+            url: ('KOBOCAT_ROOT_URI_PREFIX' in window ? KOBOCAT_ROOT_URI_PREFIX : '/') + 'api/v1/notes/' + note_id,
             type: "DELETE",
             statusCode: {
                 404: function(){

--- a/onadata/apps/viewer/templates/instance.html
+++ b/onadata/apps/viewer/templates/instance.html
@@ -165,4 +165,7 @@ $(document).ready(function(){
         });
 });
 </script>
+<script type="text/javascript">
+   var KOBOCAT_ROOT_URI_PREFIX = "{{ KOBOCAT_ROOT_URI_PREFIX }}" || "/";
+</script>
 {% endblock %}

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -158,7 +158,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'readonly.context_processors.readonly',
     'onadata.apps.main.context_processors.google_analytics',
     'onadata.apps.main.context_processors.site_name',
-    'onadata.apps.main.context_processors.base_url'
+    'onadata.apps.main.context_processors.base_url',
+    'onadata.apps.main.context_processors.kobocat_root_uri_prefix'
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
This fixes #405, by making the KOBOCAT_ROOT_URI_PREFIX variable available to instance.js using a context_processor.
This variable is then used to construct the `notes_url`.