### PR TITLE
"Could not connect with Server" when editing after configuring new internal URLs - fix

### DIFF
--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -252,17 +252,11 @@ def _get_form_url(request, username, protocol='https'):
     else:
         http_host = request.META.get('HTTP_HOST', 'ona.io')
 
-    kc_internal_host = "{}.{}".format(
-        os.getenv("KOBOCAT_PUBLIC_SUBDOMAIN"),
-        os.getenv("INTERNAL_DOMAIN_NAME"))
-
-    kc_public_host = "{}.{}".format(
-        os.getenv("KOBOCAT_PUBLIC_SUBDOMAIN"),
-        os.getenv("PUBLIC_DOMAIN_NAME"))
-
     # In case INTERNAL_DOMAIN_NAME is equal to PUBLIC_DOMAIN_NAME,
-    # configuration doesn't use docker internal network
-    is_call_internal = kc_internal_host == http_host and kc_public_host != http_host
+    # configuration doesn't use docker internal network.
+    # Don't overwrite `protocol.
+    is_call_internal = settings.KOBOCAT_INTERNAL_HOSTNAME == http_host and \
+                       settings.KOBOCAT_PUBLIC_HOSTNAME != http_host
 
     # Make sure protocol is enforced to `http` when calling `kc` internally
     protocol = "http" if is_call_internal else protocol

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -252,6 +252,21 @@ def _get_form_url(request, username, protocol='https'):
     else:
         http_host = request.META.get('HTTP_HOST', 'ona.io')
 
+    kc_internal_host = "{}.{}".format(
+        os.getenv("KOBOCAT_PUBLIC_SUBDOMAIN"),
+        os.getenv("INTERNAL_DOMAIN_NAME"))
+
+    kc_public_host = "{}.{}".format(
+        os.getenv("KOBOCAT_PUBLIC_SUBDOMAIN"),
+        os.getenv("PUBLIC_DOMAIN_NAME"))
+
+    # In case INTERNAL_DOMAIN_NAME is equal to PUBLIC_DOMAIN_NAME,
+    # configuration doesn't use docker internal network
+    is_call_internal = kc_internal_host == http_host and kc_public_host != http_host
+
+    # Make sure protocol is enforced to `http` when calling `kc` internally
+    protocol = "http" if is_call_internal else protocol
+
     return '%s://%s/%s' % (protocol, http_host, username)
 
 

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -86,6 +86,8 @@ STATIC_URL = '/static/'
 # Configurable settings.
 ENKETO_URL = os.environ.get('ENKETO_URL', 'https://enketo.kobotoolbox.org')
 KOBOCAT_URL = os.environ.get('KOBOCAT_URL', 'https://kc.kobotoolbox.org')
+
+
 ENKETO_URL= ENKETO_URL.rstrip('/')
 ENKETO_API_TOKEN = os.environ.get('ENKETO_API_TOKEN', 'enketorules')
 ENKETO_VERSION= os.environ.get('ENKETO_VERSION', 'Legacy').lower()
@@ -115,7 +117,18 @@ ENKETO_API_INSTANCE_IFRAME_URL = ENKETO_URL + ENKETO_API_ROOT + ENKETO_API_ENDPO
 KPI_URL = os.environ.get('KPI_URL', False)
 
 # specifically for site urls sent to enketo for form retrieval
+# `ENKETO_PROTOCOL` variable is overridden when internal domain name is used.
+# All internal communications between containers must be HTTP only.
 ENKETO_PROTOCOL = os.environ.get('ENKETO_PROTOCOL', 'https')
+
+# These 2 variables are needed to detect whether the ENKETO_PROTOCOL should overwritten or not.
+# See method `_get_form_url` in `onadata/libs/utils/viewer_tools.py`
+KOBOCAT_INTERNAL_HOSTNAME = "{}.{}".format(
+    os.environ.get("KOBOCAT_PUBLIC_SUBDOMAIN", "kc"),
+    os.environ.get("INTERNAL_DOMAIN_NAME", "docker.internal"))
+KOBOCAT_PUBLIC_HOSTNAME = "{}.{}".format(
+    os.environ.get("KOBOCAT_PUBLIC_SUBDOMAIN", "kc"),
+    os.environ.get("PUBLIC_DOMAIN_NAME", "kobotoolbox.org"))
 
 # Default value for the `UserProfile.require_auth` attribute. Even though it's
 # set in kc_environ, include it here as well to support legacy installations


### PR DESCRIPTION
I've added another validation in case INTERNAL_DOMAIN_NAME is equal to PUBLIC_DOMAIN_NAME.
In that case, we don't want to force the protocol.

Fixes #445 