### PR TITLE
Deleting a repeat breaks parsing of existing submissions - fix

### DIFF
--- a/onadata/apps/logger/fixtures/repeated_group/repeated_group.json
+++ b/onadata/apps/logger/fixtures/repeated_group/repeated_group.json
@@ -1,0 +1,1 @@
+{"#document": {"form": {"question_group": [{"answer_2": "2", "answer_1": "1"}, {"answer_2": "1", "answer_1": "2"}]}}}

--- a/onadata/apps/logger/fixtures/repeated_group/repeated_group.xml
+++ b/onadata/apps/logger/fixtures/repeated_group/repeated_group.xml
@@ -1,0 +1,10 @@
+<form id="rg1" version="version_1">
+<question_group>
+    <answer_1>1</answer_1>
+    <answer_2>2</answer_2>
+</question_group>
+<question_group>
+    <answer_1>2</answer_1>
+    <answer_2>1</answer_2>
+</question_group>
+</form>

--- a/onadata/apps/logger/tests/test_parsing.py
+++ b/onadata/apps/logger/tests/test_parsing.py
@@ -7,8 +7,10 @@ from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.logger.xform_instance_parser import XFormInstanceParser,\
     xpath_from_xml_node
 from onadata.apps.logger.xform_instance_parser import get_uuid_from_xml,\
-    get_meta_from_xml, get_deprecated_uuid_from_xml
+    get_meta_from_xml, get_deprecated_uuid_from_xml,\
+    _xml_node_to_dict, clean_and_parse_xml
 from onadata.libs.utils.common_tags import XFORM_ID_STRING
+
 
 XML = u"xml"
 DICT = u"dict"
@@ -166,6 +168,21 @@ class TestXFormInstanceParser(TestBase):
             "multiple_nodes_error.xml"
         )
         self._make_submission(xml_submission_file_path)
-        self.assertContains(self.response,
-                            "Multiple nodes with the same name",
-                            status_code=400)
+        self.assertEquals(201, self.response.status_code)
+
+    def test_xml_repeated_group_to_dict(self):
+        xml_file = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "../fixtures/repeated_group/repeated_group.xml"
+        )
+        json_file = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "../fixtures/repeated_group/repeated_group.json"
+        )
+        with open(xml_file) as file:
+            dict_ = _xml_node_to_dict(clean_and_parse_xml(file.read()))
+            self.assertTrue(dict_['#document']['form']['question_group'])
+            self.assertEqual(2, len(dict_['#document']['form']['question_group']))
+            with open(json_file) as jfile:
+                import json
+                self.assertEqual(jfile.read(), json.dumps(dict_))

--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -166,9 +166,18 @@ def _xml_node_to_dict(node, repeats=[]):
                 if child_name not in value:
                     value[child_name] = d[child_name]
                 else:
-                    raise InstanceMultipleNodeError(
-                        _(u"Multiple nodes with the same name '%s'"
-                          u" while not a repeat" % child_name))
+                    # Duplicate Ona solution when repeating group is not present,
+                    # but some nodes are still making references to it.
+                    # Ref: https://github.com/onaio/onadata/commit/7d65fd30348b2f9c6ed6379c7bf79a523cc5750d
+                    node_value = value[child_name]
+                    # 1. check if the node values is a list
+                    if not isinstance(node_value, list):
+                        # if not a list, create one
+                        value[child_name] = [node_value]
+                    # 2. parse the node
+                    d = _xml_node_to_dict(child, repeats)
+                    # 3. aggregate
+                    value[child_name].append(d[child_name])
             else:
                 if child_name not in value:
                     value[child_name] = [d[child_name]]

--- a/onadata/settings/test_environ.py
+++ b/onadata/settings/test_environ.py
@@ -12,6 +12,13 @@ DATABASES = {
         env='TEST_DATABASE_URL', default="sqlite:///%s/db.sqlite3" % BASE_DIR)
 }
 
+# Need to add these lines to make the tests run
+# Moreover, `apt-get update && apt-get install libsqlite3-mod-spatialite`
+#  should be executed inside the container
+DATABASES['default']['ENGINE'] = "django.contrib.gis.db.backends.spatialite"
+SPATIALITE_LIBRARY_PATH = 'mod_spatialite'
+
+
 MONGO_DATABASE = {
     'HOST': os.environ.get('KOBOCAT_MONGO_HOST', 'mongo'),
     'PORT': int(os.environ.get('KOBOCAT_MONGO_PORT', 27017)),


### PR DESCRIPTION
As discussed with @jnm, multiple nodes with the same name are now allowed (even if they don't belong to a repeated group)

Fixes #426 