### PR TITLE
Install S3 requirements properly; fixes #454

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,18 @@ RUN if ! diff "${KOBOCAT_TMP_DIR}/current_apt_requirements.txt" "${KOBOCAT_TMP_D
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     ; fi
 
+# Version 8 of pip doesn't really seem to upgrade packages when switching from
+# PyPI to editable Git
+RUN pip install --upgrade 'pip>=10,<11'
+
 # Install post-base-image `pip` additions/upgrades from `requirements/base.pip`, if modified.
 COPY ./requirements/ "${KOBOCAT_TMP_DIR}/current_requirements/"
 # FIXME: Replace this with the much simpler command `pip-sync ${KOBOCAT_TMP_DIR}/current_requirements/base.pip`.
 RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" "${KOBOCAT_TMP_DIR}/base_requirements/base.pip"; then \
         pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" \
     ; fi
+
+# Install post-base-image `pip` additions/upgrades from `requirements/s3.pip`, if modified.
 RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" "${KOBOCAT_TMP_DIR}/base_requirements/s3.pip"; then \
         pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" \
     ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ COPY ./requirements/ "${KOBOCAT_TMP_DIR}/current_requirements/"
 RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" "${KOBOCAT_TMP_DIR}/base_requirements/base.pip"; then \
         pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" \
     ; fi
+RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" "${KOBOCAT_TMP_DIR}/base_requirements/s3.pip"; then \
+        pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" \
+    ; fi
 
 # Uninstall `pip` packages installed in the base image from `requirements/uninstall.pip`, if present.
 # FIXME: Replace this with the much simpler `pip-sync` command equivalent.

--- a/Dockerfile.kobocat_base
+++ b/Dockerfile.kobocat_base
@@ -27,6 +27,7 @@ RUN apt-get update && \
 
 COPY ./requirements/ ${KOBOCAT_TMP_DIR}/base_requirements/
 RUN mkdir -p ${PIP_EDITABLE_PACKAGES_DIR} && \
+    pip install --upgrade 'pip>=10,<11' && \
     pip install --src ${PIP_EDITABLE_PACKAGES_DIR}/ -r ${KOBOCAT_TMP_DIR}/base_requirements/base.pip && \
     pip install --src ${PIP_EDITABLE_PACKAGES_DIR}/ -r ${KOBOCAT_TMP_DIR}/base_requirements/s3.pip && \
     rm -rf ~/.cache/pip

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -1,4 +1,4 @@
-boto==2.48.1
+boto==2.48.0
 
 # Change this back to the PyPI package once
 # https://github.com/jschneier/django-storages/pull/504 is merged and released


### PR DESCRIPTION
* Fix typo in `boto` requirement;
* Upgrade `pip` from 8 to better-behaved 10;
* Check `s3.pip` as well as `base.pip` when building from the main `Dockerfile`.