### PR TITLE
Fix memory leak by requiring a newer version of django-storages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,18 @@ RUN if ! diff "${KOBOCAT_TMP_DIR}/current_apt_requirements.txt" "${KOBOCAT_TMP_D
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     ; fi
 
+# Version 8 of pip doesn't really seem to upgrade packages when switching from
+# PyPI to editable Git
+RUN pip install --upgrade 'pip>=10,<11'
+
 # Install post-base-image `pip` additions/upgrades from `requirements/base.pip`, if modified.
 COPY ./requirements/ "${KOBOCAT_TMP_DIR}/current_requirements/"
 # FIXME: Replace this with the much simpler command `pip-sync ${KOBOCAT_TMP_DIR}/current_requirements/base.pip`.
 RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" "${KOBOCAT_TMP_DIR}/base_requirements/base.pip"; then \
         pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" \
     ; fi
+
+# Install post-base-image `pip` additions/upgrades from `requirements/s3.pip`, if modified.
 RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" "${KOBOCAT_TMP_DIR}/base_requirements/s3.pip"; then \
         pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" \
     ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ COPY ./requirements/ "${KOBOCAT_TMP_DIR}/current_requirements/"
 RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" "${KOBOCAT_TMP_DIR}/base_requirements/base.pip"; then \
         pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/base.pip" \
     ; fi
+RUN if ! diff "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" "${KOBOCAT_TMP_DIR}/base_requirements/s3.pip"; then \
+        pip install --src "${PIP_EDITABLE_PACKAGES_DIR}/" -r "${KOBOCAT_TMP_DIR}/current_requirements/s3.pip" \
+    ; fi
 
 # Uninstall `pip` packages installed in the base image from `requirements/uninstall.pip`, if present.
 # FIXME: Replace this with the much simpler `pip-sync` command equivalent.

--- a/Dockerfile.kobocat_base
+++ b/Dockerfile.kobocat_base
@@ -27,6 +27,7 @@ RUN apt-get update && \
 
 COPY ./requirements/ ${KOBOCAT_TMP_DIR}/base_requirements/
 RUN mkdir -p ${PIP_EDITABLE_PACKAGES_DIR} && \
+    pip install --upgrade 'pip>=10,<11' && \
     pip install --src ${PIP_EDITABLE_PACKAGES_DIR}/ -r ${KOBOCAT_TMP_DIR}/base_requirements/base.pip && \
     pip install --src ${PIP_EDITABLE_PACKAGES_DIR}/ -r ${KOBOCAT_TMP_DIR}/base_requirements/s3.pip && \
     rm -rf ~/.cache/pip

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -456,7 +456,7 @@ CELERYD_TASK_SOFT_TIME_LIMIT = int(os.environ.get(
     'CELERYD_TASK_SOFT_TIME_LIMIT', 1800))
 
 # duration to keep zip exports before deletion (in seconds)
-ZIP_EXPORT_COUNTDOWN = 3600  # 1 hour
+ZIP_EXPORT_COUNTDOWN = 24 * 60 * 60
 
 # default content length for submission requests
 DEFAULT_CONTENT_LENGTH = 10000000

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -1,4 +1,4 @@
-boto==2.48.1
+boto==2.48.0
 
 # Change this back to the PyPI package once
 # https://github.com/jschneier/django-storages/pull/504 is merged and released

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -1,5 +1,5 @@
 boto==2.48.0
 
 # Change this back to the PyPI package once
-# https://github.com/jschneier/django-storages/pull/504 is merged and released
--e git+https://github.com/jnm/django-storages@175ad806098fd1d139b6e1d2585fdf9295395e43#egg=django_storages
+# https://github.com/jschneier/django-storages/pull/506 is merged and released
+-e git+https://github.com/jnm/django-storages@s3boto-s3boto3-truncate-buffer-after-uploading#egg=django_storages


### PR DESCRIPTION
and increase the lifespan of ZIP exports to 24 hours. Fixes #456.

Builds on top of #455.
