### PR TITLE
Use a fork of `django-storages` to fix corrupt ZIP

### DIFF
--- a/onadata/libs/utils/export_tools.py
+++ b/onadata/libs/utils/export_tools.py
@@ -842,10 +842,10 @@ def generate_attachments_zip_export(
 
     export_filename = get_storage_class()().save(file_path, ContentFile(''))
 
-    with get_storage_class()().open(file_path, 'wb') as destination_file:
+    with get_storage_class()().open(export_filename, 'wb') as destination_file:
         create_attachments_zipfile(
             attachments,
-            temporary_file=destination_file, # not "temporary" anymore...
+            output_file=destination_file,
         )
 
     dir_name, basename = os.path.split(export_filename)

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -225,12 +225,12 @@ def enketo_url(form_url, id_string, instance_xml=None,
     return False
 
 
-def create_attachments_zipfile(attachments, temporary_file=None):
-    if not temporary_file:
-        temporary_file = NamedTemporaryFile()
+def create_attachments_zipfile(attachments, output_file=None):
+    if not output_file:
+        output_file = NamedTemporaryFile()
 
     storage = get_storage_class()()
-    with zipfile.ZipFile(temporary_file, 'w', zipfile.ZIP_STORED, allowZip64=True) as zip_file:
+    with zipfile.ZipFile(output_file, 'w', zipfile.ZIP_STORED, allowZip64=True) as zip_file:
         for attachment in attachments:
             if storage.exists(attachment.media_file.name):
                 try:
@@ -239,10 +239,7 @@ def create_attachments_zipfile(attachments, temporary_file=None):
                 except Exception, e:
                     report_exception("Error adding file \"{}\" to archive.".format(attachment.media_file.name), e)
 
-    # Be kind; rewind.
-    temporary_file.seek(0)
-
-    return temporary_file
+    return output_file
 
 
 def _get_form_url(request, username, protocol='https'):

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -1,5 +1,5 @@
 boto==2.48.0
 
-# Change this back to the PyPI package once
-# https://github.com/jschneier/django-storages/pull/506 is merged and released
--e git+https://github.com/jnm/django-storages@s3boto-s3boto3-truncate-buffer-after-uploading#egg=django_storages
+# Necessary to use this fork until the resolution of
+# https://github.com/jschneier/django-storages/issues/566
+-e git+https://github.com/jnm/django-storages@s3boto_accurate_tell#egg=django_storages


### PR DESCRIPTION
exports. Closes #475. See https://github.com/jnm/django-storages/commit/119d8fe694341f2c93afb9c0c3d078ed928ac017 for the meaningful changes.