### PR TITLE
Remove (broken) synchronous ZIP export

### DIFF
--- a/onadata/apps/main/tests/test_form_exports.py
+++ b/onadata/apps/main/tests/test_form_exports.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from xlrd import open_workbook
 
 from onadata.apps.viewer.models.export import Export
-from onadata.apps.viewer.views import zip_export, kml_export, export_download
+from onadata.apps.viewer.views import kml_export, export_download
 from onadata.libs.utils.export_tools import generate_export
 from onadata.libs.utils.user_auth import http_auth_string
 from test_base import TestBase
@@ -113,19 +113,6 @@ class TestFormExports(TestBase):
         response = self.anon.get(self.xls_url)
         self.assertEqual(response.status_code, 403)
 
-    def test_zip_raw_export_name(self):
-        url = reverse(zip_export, kwargs={'username': self.user.username,
-                                          'id_string': self.xform.id_string})
-        response = self.client.get(url + '?raw=1')
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['Content-Disposition'], 'attachment;')
-
-    def test_restrict_zip_export_if_not_shared(self):
-        url = reverse(zip_export, kwargs={'username': self.user.username,
-                                          'id_string': self.xform.id_string})
-        response = self.anon.get(url)
-        self.assertEqual(response.status_code, 403)
-
     def test_restrict_kml_export_if_not_shared(self):
         url = reverse(kml_export, kwargs={'username': self.user.username,
                                           'id_string': self.xform.id_string})
@@ -144,14 +131,6 @@ class TestFormExports(TestBase):
         response = self.anon.get(self.xls_url)
         self.assertEqual(response.status_code, 200)
 
-    def test_allow_zip_export_if_shared(self):
-        self.xform.shared_data = True
-        self.xform.save()
-        url = reverse(zip_export, kwargs={'username': self.user.username,
-                                          'id_string': self.xform.id_string})
-        response = self.anon.get(url)
-        self.assertEqual(response.status_code, 200)
-
     def test_allow_kml_export_if_shared(self):
         self.xform.shared_data = True
         self.xform.save()
@@ -166,12 +145,6 @@ class TestFormExports(TestBase):
 
     def test_allow_xls_export(self):
         response = self.client.get(self.xls_url)
-        self.assertEqual(response.status_code, 200)
-
-    def test_allow_zip_export(self):
-        url = reverse(zip_export, kwargs={'username': self.user.username,
-                                          'id_string': self.xform.id_string})
-        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_allow_kml_export(self):
@@ -194,16 +167,6 @@ class TestFormExports(TestBase):
                                                    self.login_password)
         }
         response = self.anon.get(self.xls_url, **extra)
-        self.assertEqual(response.status_code, 200)
-
-    def test_allow_zip_export_for_basic_auth(self):
-        extra = {
-            'HTTP_AUTHORIZATION': http_auth_string(self.login_username,
-                                                   self.login_password)
-        }
-        url = reverse(zip_export, kwargs={'username': self.user.username,
-                                          'id_string': self.xform.id_string})
-        response = self.anon.get(url, **extra)
         self.assertEqual(response.status_code, 200)
 
     def test_allow_kml_export_for_basic_auth(self):

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -155,8 +155,6 @@ urlpatterns = patterns(
         kwargs={'export_type': 'sav_zip'}),
     url(r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.kml$",
         'onadata.apps.viewer.views.kml_export'),
-    url(r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.zip",
-        'onadata.apps.viewer.views.zip_export'),
     url(r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/gdocs$",
         'onadata.apps.viewer.views.google_xls_export'),
     url(r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/map_embed",


### PR DESCRIPTION
While checking over https://github.com/kobotoolbox/kobocat/pull/476, I noticed
that https://[kc-host]/[username]/forms/[id_string]/data.zip did not work even
prior to the changes in that PR.