### PR TITLE
Replace safe filter with urlencode filter in Briefcase API template

### DIFF
--- a/onadata/apps/logger/templates/downloadSubmission.xml
+++ b/onadata/apps/logger/templates/downloadSubmission.xml
@@ -6,6 +6,6 @@
     {% for media in media_files %}<mediaFile>
         <filename>{{ media.filename|safe }}</filename>
         <hash>md5:{{ media.file_hash }}</hash>
-        <downloadUrl>{{ host }}{% url "onadata.apps.viewer.views.attachment_url" 'original' %}?media_file={{ media.media_file.name|safe }}</downloadUrl>
+        <downloadUrl>{{ host }}{% url "onadata.apps.viewer.views.attachment_url" 'original' %}?media_file={{ media.media_file.name|urlencode }}</downloadUrl>
     </mediaFile>{% endfor %}
 </submission>


### PR DESCRIPTION
I originally posted an issue about this in the kobo-kpi repo by mistake, sorry! https://github.com/kobotoolbox/kpi/issues/1863

It turns out that the `media_file` query string value of the `downloadUrl` element of the XML files Kobo generates for Briefcase was being filtered with `safe`, which would be OK for variables interpolated in HTML strings, but for stuff that goes into URLs, we should have a `urlencode` filter instead.

Full disclosure: I haven't tested this. The change is based on Django literature