### PR TITLE
Used 'request.get_host()' instead of 'request.META.get('HTTP_HOST')'

### DIFF
--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -735,7 +735,7 @@ def ziggy_submissions(request, username):
 @user_passes_test(lambda u: u.is_superuser)
 def superuser_stats(request, username):
     base_filename = '{}_{}_{}.zip'.format(
-        re.sub('[^a-zA-Z0-9]', '-', request.META['HTTP_HOST']),
+        re.sub('[^a-zA-Z0-9]', '-', request.get_host()),
         datetime_module.date.today(),
         datetime_module.datetime.now().microsecond
     )

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -1415,7 +1415,7 @@ def activity_api(request, username):
 
 def qrcode(request, username, id_string):
     try:
-        formhub_url = "http://%s/" % request.META['HTTP_HOST']
+        formhub_url = "http://%s/" % request.get_host()
     except:
         formhub_url = "http://formhub.org/"
     formhub_url = formhub_url + username

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -169,6 +169,7 @@ def get_client_ip(request):
 
 def enketo_url(form_url, id_string, instance_xml=None,
                instance_id=None, return_url=None, instance_attachments=None):
+
     if not hasattr(settings, 'ENKETO_URL')\
             and not hasattr(settings, 'ENKETO_API_SURVEY_PATH'):
         return False
@@ -182,6 +183,7 @@ def enketo_url(form_url, id_string, instance_xml=None,
         'form_id': id_string,
         'server_url': form_url
     }
+
     if instance_id is not None and instance_xml is not None:
         url = settings.ENKETO_URL + settings.ENKETO_API_INSTANCE_PATH
         values.update({
@@ -240,7 +242,7 @@ def _get_form_url(request, username, protocol='https'):
         http_host = settings.TEST_HTTP_HOST
         username = settings.TEST_USERNAME
     else:
-        http_host = request.META.get('HTTP_HOST', 'ona.io')
+        http_host = request.get_host()
 
     # In case INTERNAL_DOMAIN_NAME is equal to PUBLIC_DOMAIN_NAME,
     # configuration doesn't use docker internal network.

--- a/onadata/settings/test_environ.py
+++ b/onadata/settings/test_environ.py
@@ -39,7 +39,7 @@ ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '*').split(' ')
 
 TESTING_MODE = True
 
-MEDIA_URL= '/' + os.environ.get('KOBOCAT_MEDIA_URL', 'media').strip('/') + '/'
+MEDIA_URL = '/' + os.environ.get('KOBOCAT_MEDIA_URL', 'media').strip('/') + '/'
 STATIC_URL = '/static/'
 LOGIN_URL = '/accounts/login/'
 LOGIN_REDIRECT_URL = '/login_redirect/'


### PR DESCRIPTION
Django reads NginX `$http_host` variable to build absolute urls.
When using `runserver_plus`, `$http_host` contains internal port which is incorrect. 
We pass the correct value through the header `X_FORWARD_HTTP_HOST`. 

`Request.META.get('HTTP_HOST')` doesn't report the value correctly where as `request.get_host()` does. 

Fixes #535 