### PR TITLE
Bring back old urls for attachments for retro-compability with 'kpi'

### DIFF
--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -70,6 +70,7 @@ urlpatterns = patterns(
     url(r"^{}$".format(settings.MEDIA_URL.lstrip('/')), 'onadata.apps.viewer.views.attachment_url'),
     url(r"^{}(?P<size>[^/]+)$".format(settings.MEDIA_URL.lstrip('/')),
         'onadata.apps.viewer.views.attachment_url'),
+    url(r"^media-endpoint/$", 'onadata.apps.main.views.media_endpoint'),
     url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog',
         {'packages': ('main', 'viewer',)}),
     url(r'^typeahead_usernames', 'onadata.apps.main.views.username_list',

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -62,6 +62,11 @@ urlpatterns = patterns(
     url(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)/stats$',
         'onadata.apps.viewer.views.charts', name='form-stats'),
     url(r'^login_redirect/$', 'onadata.apps.main.views.login_redirect'),
+    # Bring back old url because it's still used by `kpi`
+    # ToDo Remove when `kpi#gallery-2` is merged into master
+    url(r"^attachment/$", 'onadata.apps.viewer.views.attachment_url'),
+    url(r"^attachment/(?P<size>[^/]+)$",
+        'onadata.apps.viewer.views.attachment_url'),
     url(r"^{}$".format(settings.MEDIA_URL.lstrip('/')), 'onadata.apps.viewer.views.attachment_url'),
     url(r"^{}(?P<size>[^/]+)$".format(settings.MEDIA_URL.lstrip('/')),
         'onadata.apps.viewer.views.attachment_url'),

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -1471,3 +1471,13 @@ def username_list(request):
         data = [user['username'] for user in users]
 
     return HttpResponse(json.dumps(data), content_type='application/json')
+
+@require_GET
+def media_endpoint(request):
+    """
+    Returns medias endpoint prefix.
+    :param request:
+    :return: dict
+    """
+    data = {"result": settings.MEDIA_URL}
+    return HttpResponse(json.dumps(data), content_type='application/json')


### PR DESCRIPTION
Fixes #536.
A new endpoint has been created to be used by UI (i.e. `kpi`) to know what is the correct value.
Maybe frontend could use this endpoint to build media urls instead of an hardcoded value. (cc @magicznyleszek )
