### PR TITLE
Update attachments dict for Instance in Mongo

### DIFF
--- a/onadata/apps/logger/models/attachment.py
+++ b/onadata/apps/logger/models/attachment.py
@@ -6,6 +6,7 @@ from hashlib import md5
 
 from django.conf import settings
 from django.db import models
+from django.utils.http import urlencode
 
 from instance import Instance
 
@@ -77,5 +78,5 @@ class Attachment(models.Model):
             kobocat_url=settings.KOBOCAT_URL,
             media_url=settings.MEDIA_URL,
             suffix=suffix,
-            filename=self.media_file.name
+            filename=urlencode({"media_file": self.media_file.name})
         )

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -70,7 +70,6 @@ urlpatterns = patterns(
     url(r"^{}$".format(settings.MEDIA_URL.lstrip('/')), 'onadata.apps.viewer.views.attachment_url'),
     url(r"^{}(?P<size>[^/]+)$".format(settings.MEDIA_URL.lstrip('/')),
         'onadata.apps.viewer.views.attachment_url'),
-    url(r"^media-endpoint/$", 'onadata.apps.main.views.media_endpoint'),
     url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog',
         {'packages': ('main', 'viewer',)}),
     url(r'^typeahead_usernames', 'onadata.apps.main.views.username_list',

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -1471,13 +1471,3 @@ def username_list(request):
         data = [user['username'] for user in users]
 
     return HttpResponse(json.dumps(data), content_type='application/json')
-
-@require_GET
-def media_endpoint(request):
-    """
-    Returns medias endpoint prefix.
-    :param request:
-    :return: dict
-    """
-    data = {"result": settings.MEDIA_URL}
-    return HttpResponse(json.dumps(data), content_type='application/json')

--- a/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
+++ b/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+import sys
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils.http import urlencode
+from django.utils.translation import ugettext_lazy as _
+
+from onadata.apps.viewer.models.parsed_instance import xform_instances
+
+
+class Command(BaseCommand):
+
+    help = _("Rewrite attachments urls to point to new protected endpoint")
+
+    def handle(self, *args, **kwargs):
+
+        query = {"$and": [
+            {"_deleted_at": {"$exists": False}},
+            {"_deleted_at": None},
+            {"_attachments": {"$ne": ""}},
+            {"_attachments": {"$ne": []}}
+        ]}
+
+        results = xform_instances.find(query)
+        instances_count = results.count()
+        done = 0
+        if instances_count > 0:
+            for instance in results:
+                for attachment in instance.get("_attachments"):
+                    filename = attachment.get("filename")
+                    attachment["download_url"] = self.__secure_url(filename)
+                    for suffix in settings.THUMB_CONF.keys():
+                        attachment["download_{}_url".format(suffix)] = self.__secure_url(filename, suffix)
+
+                done += 1
+                time.sleep(1)
+
+                xform_instances.save(instance)
+                sys.stdout.write(
+                    "%.2f %% done ...\r" % ((float(done) / float(instances_count)) * 100))
+
+    @staticmethod
+    def __secure_url(filename, suffix="original"):
+        """
+        Returns image URL through kobocat redirector.
+        :param filename: str. relative path to filename
+        :param suffix: str. original|large|medium|small
+        :return: str
+        """
+        return "{kobocat_url}{media_url}{suffix}?{media_file}".format(
+            kobocat_url=settings.KOBOCAT_URL,
+            media_url=settings.MEDIA_URL,
+            suffix=suffix,
+            media_file=urlencode({"media_file": filename})
+        )

--- a/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
+++ b/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
@@ -37,7 +37,8 @@ class Command(BaseCommand):
                             # Replace them with the new `dict` format
                             if type(attachment) != dict:
                                 filename = attachment
-                                xform_id, id, mimetype = self.__get_relationship(instance.get("_id"), filename)
+                                xform_id, id, mimetype = self.__get_relationship(
+                                    instance.get("_id"), filename)
                                 attachment = {
                                     "mimetype": mimetype,
                                     "download_url": self.__secure_url(filename),
@@ -48,10 +49,12 @@ class Command(BaseCommand):
                                 }
                             else:
                                 filename = attachment.get("filename")
-                                attachment["download_url"] = self.__secure_url(filename)
+                                attachment["download_url"] = self.__secure_url(
+                                    filename)
 
                             for suffix in settings.THUMB_CONF.keys():
-                                attachment["download_{}_url".format(suffix)] = self.__secure_url(filename, suffix)
+                                attachment["download_{}_url".format(suffix)] = \
+                                    self.__secure_url(filename, suffix)
 
                         except Exception as e:
                             print("ERROR - {}".format(str(e)))
@@ -60,7 +63,10 @@ class Command(BaseCommand):
                     done += 1
                     self.__last_id = instance.get("_id")
                     xform_instances.save(instance)
-                    progress = "\r(%s/%s records) - %.2f %% done..." % (done, instances_count, (float(done) / float(instances_count)) * 100)
+                    progress = "\r(%s/%s records) - %.2f %% done..." % (
+                        done, instances_count,
+                        (float(done) / float(instances_count)) * 100
+                    )
                     sys.stdout.write(progress)
                     sys.stdout.flush()
 

--- a/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
+++ b/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import json
 import sys
+import time
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -10,38 +11,80 @@ from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 
 from onadata.apps.viewer.models.parsed_instance import xform_instances
+from onadata.apps.logger.models.instance import Instance
 
 
 class Command(BaseCommand):
 
     help = _("Rewrite attachments urls to point to new protected endpoint")
+    BATCH_SIZE = 1000
 
     def handle(self, *args, **kwargs):
 
+        self.__cached_instances = {}
+        self.__last_id = None
+
+        cursor = self.__get_data()
+        instances_count = cursor.count()
+        done = 0
+        stop = False
+        while stop is not True:
+            batch_count = cursor.count(True)
+            if batch_count > 0:
+                for instance in cursor:
+                    for attachment in instance.get("_attachments"):
+                        try:
+                            if type(attachment) != dict:  # seems that old instances, do not use the
+                                filename = attachment
+                                xform_id, id, mimetype = self.__get_relationship(instance.get("_id"), filename)
+                                attachment = {
+                                    "mimetype": mimetype,
+                                    "download_url": self.__secure_url(filename),
+                                    "filename": filename,
+                                    "instance": instance.get("_id"),
+                                    "id": id,
+                                    "xform": xform_id
+                                }
+                            else:
+                                filename = attachment.get("filename")
+                                attachment["download_url"] = self.__secure_url(filename)
+
+                            for suffix in settings.THUMB_CONF.keys():
+                                attachment["download_{}_url".format(suffix)] = self.__secure_url(filename, suffix)
+
+                        except Exception as e:
+                            print("ERROR - {}".format(str(e)))
+                            print(instance)
+
+                    done += 1
+                    self.__last_id = instance.get("_id")
+                    xform_instances.save(instance)
+                    progress = "\r(%s/%s records) - %.2f %% done..." % (done, instances_count, (float(done) / float(instances_count)) * 100)
+                    sys.stdout.write(progress)
+                    sys.stdout.flush()
+
+                settings.MONGO_CONNECTION.admin.command({'fsync': 1})
+                cursor = self.__get_data()
+            else:
+                stop = True
+
+        sys.stdout.write("\nUpdated %s records\n" % instances_count)
+
+    def __get_data(self):
         query = {"$and": [
             {"_deleted_at": {"$exists": False}},
             {"_deleted_at": None},
             {"_attachments": {"$ne": ""}},
-            {"_attachments": {"$ne": []}}
+            {"_attachments": {"$ne": []}},
+            {"_attachments.download_small_url": {"$exists": False}}
         ]}
 
-        results = xform_instances.find(query)
-        instances_count = results.count()
-        done = 0
-        if instances_count > 0:
-            for instance in results:
-                for attachment in instance.get("_attachments"):
-                    filename = attachment.get("filename")
-                    attachment["download_url"] = self.__secure_url(filename)
-                    for suffix in settings.THUMB_CONF.keys():
-                        attachment["download_{}_url".format(suffix)] = self.__secure_url(filename, suffix)
+        if self.__last_id is not None:
+            query.update({
+                "_id": {"$gt": self.__last_id}
+            })
 
-                done += 1
-                time.sleep(1)
-
-                xform_instances.save(instance)
-                sys.stdout.write(
-                    "%.2f %% done ...\r" % ((float(done) / float(instances_count)) * 100))
+        return xform_instances.find(query).limit(self.BATCH_SIZE)
 
     @staticmethod
     def __secure_url(filename, suffix="original"):
@@ -57,3 +100,35 @@ class Command(BaseCommand):
             suffix=suffix,
             media_file=urlencode({"media_file": filename})
         )
+
+    def __get_relationship(self, instance_id, filename):
+        """
+        Retrieves XForm, Attachment Id & mimetype of filename
+
+        This method can be hard on RAM.
+
+        Maybe needs some garbage collecting logic
+        :param instance_id: int
+        :param filename: str
+        :return: tuple
+        """
+
+        if instance_id not in self.__cached_instances:
+            instance = Instance.objects.get(id=instance_id)
+            self.__cached_instances[instance_id] = {
+                "xform_id": instance.xform.id,
+                "attachments": [{
+                    "mimetype": attachment.mimetype,
+                    "filename": attachment.media_file,
+                    "id": attachment.id
+                } for attachment in instance.attachments.all()]
+            }
+
+        for attachment in self.__cached_instances[instance_id].get("attachments"):
+            if filename == attachment.get("filename"):
+                return (self.__cached_instances[instance_id].get("xform_id"),
+                        attachment.get("id"),
+                        attachment.get("mimetype"))
+
+        return None, None, None
+

--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -192,8 +192,8 @@ class ParsedInstance(models.Model):
             fields = json.loads(fields, object_hook=json_util.object_hook)
         fields = fields if fields else []
 
-        # TODO: current mongo (2.0.4 of this writing)
-        # cant mix including and excluding fields in a single query
+        # TODO: current mongo (3.4 of this writing)
+        # cannot mix including and excluding fields in a single query
         if type(fields) == list and len(fields) > 0:
             fields_to_select = dict(
                 [(MongoHelper.encode(field), 1) for field in fields])
@@ -205,7 +205,7 @@ class ParsedInstance(models.Model):
         """
         Applies pagination and sorting on mongo cursor.
 
-        :param mongo_cursor: pymongo.cursor.Cursor
+        :param cursor: pymongo.cursor.Cursor
         :param start: integer
         :param limit: integer
         :param sort: dict

--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -363,6 +363,8 @@ def _get_attachments_from_instance(instance):
     for a in instance.attachments.all():
         attachment = dict()
         attachment['download_url'] = a.secure_url()
+        for suffix in settings.THUMB_CONF.keys():
+            attachment['download_{}_url'.format(suffix)] = a.secure_url(suffix)
         attachment['mimetype'] = a.mimetype
         attachment['filename'] = a.media_file.name
         attachment['instance'] = a.instance.pk

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -35,7 +35,6 @@ def get_dimensions((width, height), longest_side):
     return flat(width, height)
 
 
-
 def _save_thumbnails(image, original_path, size, suffix):
     # Thumbnail format will be set by original file extension.
     # Use same format to keep transparency of GIF/PNG

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -35,14 +35,14 @@ def get_dimensions((width, height), longest_side):
     return flat(width, height)
 
 
-def _save_thumbnails(image, path, size, suffix):
+
+def _save_thumbnails(image, original_path, size, suffix):
+    # Thumbnail format will be set by original file extension.
+    # Use same format to keep transparency of GIF/PNG
     nm = NamedTemporaryFile(suffix='.%s' % image.format)
     default_storage = get_storage_class()()
     try:
         # Ensure conversion to float in operations
-        # Converting to RGBA make the background white instead of black for
-        # transparent PNGs/GIFs
-        image = image.convert("RGBA")
         image.thumbnail(get_dimensions(image.size, float(size)), Image.ANTIALIAS)
     except ZeroDivisionError:
         pass
@@ -57,39 +57,40 @@ def _save_thumbnails(image, path, size, suffix):
     # i.e if `file_<suffix>.jpg` exists, Storage will save `a_<suffix>_<random_string>.jpg`
     # but nothing in the code is aware about this `<random_string>
     try:
-        default_storage.delete(get_path(path, suffix))
+        default_storage.delete(get_path(original_path, suffix))
     except IOError:
         pass
 
     default_storage.save(
-        get_path(path, suffix), ContentFile(nm.read()))
+        get_path(original_path, suffix), ContentFile(nm.read()))
 
     nm.close()
 
 
 def resize(filename):
     default_storage = get_storage_class()()
-    path = default_storage.url(filename)
-    req = requests.get(path)
-    if req.status_code == 200:
-        im = StringIO(req.content)
-        image = Image.open(im)
+    is_local = default_storage.__class__.__name__ == 'FileSystemStorage'
+    image = None
+    original_path = None
+
+    if is_local:
+        path = default_storage.path(filename)
+        image = Image.open(path)
+        original_path = path
+    else:
+        path = default_storage.url(filename)
+        original_path = filename
+        req = requests.get(path)
+        if req.status_code == 200:
+            im = StringIO(req.content)
+            image = Image.open(im)
+
+    if image:
         conf = settings.THUMB_CONF
         [_save_thumbnails(
-            image, filename,
+            image, original_path,
             conf[key]['size'],
             conf[key]['suffix']) for key in settings.THUMB_ORDER]
-
-
-def resize_local_env(filename):
-    default_storage = get_storage_class()()
-    path = default_storage.path(filename)
-    image = Image.open(path)
-    conf = settings.THUMB_CONF
-
-    [_save_thumbnails(
-        image, path, conf[key]['size'],
-        conf[key]['suffix']) for key in settings.THUMB_ORDER]
 
 
 def image_url(attachment, suffix):
@@ -101,20 +102,16 @@ def image_url(attachment, suffix):
         return url
     else:
         default_storage = get_storage_class()()
-        fs = get_storage_class('django.core.files.storage.FileSystemStorage')()
         if suffix in settings.THUMB_CONF:
             size = settings.THUMB_CONF[suffix]['suffix']
             filename = attachment.media_file.name
             if default_storage.exists(filename):
-                if default_storage.exists(get_path(filename, size)) and\
+                if default_storage.exists(get_path(filename, size)) and \
                         default_storage.size(get_path(filename, size)) > 0:
                     url = default_storage.url(
                         get_path(filename, size))
                 else:
-                    if default_storage.__class__ != fs.__class__:
-                        resize(filename)
-                    else:
-                        resize_local_env(filename)
+                    resize(filename)
                     return image_url(attachment, suffix)
             else:
                 return None

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -419,7 +419,6 @@ THUMB_CONF = {
 }
 # order of thumbnails from largest to smallest
 THUMB_ORDER = ['large', 'medium', 'small']
-IMG_FILE_TYPE = 'jpg'
 
 # Number of times Celery retries to send data to external rest service
 REST_SERVICE_MAX_RETRIES = 3


### PR DESCRIPTION
- Methods to create thumbnails have been refactoring into one 
- `small`, `medium`, `large` urls have been added to dict saved in Mongo
- Management command to update instances in Mongo
- `media_endpoint` is removed. (Useless because urls are correctly exposed in Mongo now)