### PR TITLE
Quick fix for non-ASCII attachment filenames

### DIFF
--- a/onadata/apps/logger/models/attachment.py
+++ b/onadata/apps/logger/models/attachment.py
@@ -73,7 +73,7 @@ class Attachment(models.Model):
         if suffix != "original" and suffix not in settings.THUMB_CONF.keys():
             raise Exception("Invalid image thumbnail")
 
-        return "{kobocat_url}{media_url}{suffix}?media_file={filename}".format(
+        return u"{kobocat_url}{media_url}{suffix}?media_file={filename}".format(
             kobocat_url=settings.KOBOCAT_URL,
             media_url=settings.MEDIA_URL,
             suffix=suffix,


### PR DESCRIPTION
Fixes #546