### PR TITLE
Use KPI `Asset.uid` when available to build `kpi_hook` endpoint

### DIFF
--- a/kobocat-template/templates/show.html
+++ b/kobocat-template/templates/show.html
@@ -890,12 +890,6 @@ $(document).ready(function() {
     {% endif %}
     });
 
-  // REST Service
-  $(document).ready(function() {
-      $.get('{% url "onadata.apps.restservice.views.add_service" content_user.username xform.id_string %}', function(data){
-          $('#restservice_tab').html(data);
-      });
-  });
 </script>
 
     <!-- NEW SANDBOX JQUERY CALLS -->

--- a/onadata/apps/logger/fields.py
+++ b/onadata/apps/logger/fields.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.core.exceptions import FieldError
 from django.db import models
 
 

--- a/onadata/apps/logger/migrations/0012_add_asset_uid_to_xform.py
+++ b/onadata/apps/logger/migrations/0012_add_asset_uid_to_xform.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('logger', '0011_add-index-to-instance-uuid_and_xform_uuid'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='xform',
+            name='kpi_asset_uid',
+            field=models.CharField(max_length=32, null=True),
+        ),
+    ]

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -96,6 +96,7 @@ class XForm(BaseModel):
     tags = TaggableManager()
 
     has_kpi_hooks = LazyDefaultBooleanField(default=False)
+    kpi_asset_uid = models.CharField(max_length=32, null=True)
 
     class Meta:
         app_label = 'logger'

--- a/onadata/apps/main/templates/show.html
+++ b/onadata/apps/main/templates/show.html
@@ -740,12 +740,5 @@ $(document).ready(function() {
             {% endif %}
             });
 
-        // REST Service
-            $(document).ready(function() {
-                $.get('{% url "onadata.apps.restservice.views.add_service" content_user.username xform.id_string %}', function(data){
-                    $('#restservice_tab').html(data);
-                });
-            });
-
         </script>
 {% endblock %}

--- a/onadata/apps/main/templates/show_form_settings.html
+++ b/onadata/apps/main/templates/show_form_settings.html
@@ -740,12 +740,5 @@ $(document).ready(function() {
             {% endif %}
             });
 
-        // REST Service
-            $(document).ready(function() {
-                $.get('{% url "onadata.apps.restservice.views.add_service" content_user.username xform.id_string %}', function(data){
-                    $('#restservice_tab').html(data);
-                });
-            });
-
         </script>
 {% endblock %}

--- a/onadata/apps/restservice/signals.py
+++ b/onadata/apps/restservice/signals.py
@@ -20,10 +20,13 @@ def save_kpi_hook_service(sender, instance, **kwargs):
     if instance.has_kpi_hooks:
         # Only register the service if it hasn't been created yet.
         if kpi_hook_service is None:
-
+            # For retro-compatibility, if `asset_uid` is null, fallback on
+            # `id_string`
+            asset_uid = instance.kpi_asset_uid if instance.kpi_asset_uid \
+                else instance.id_string
             kpi_hook_service = RestService(
                 service_url=settings.KPI_HOOK_ENDPOINT_PATTERN.format(
-                    asset_uid=instance.id_string),
+                    asset_uid=asset_uid),
                 xform=instance,
                 name=SERVICE_KPI_HOOK[0]
             )


### PR DESCRIPTION
This PR closes #577 but also fixes a bug introduced by https://github.com/kobotoolbox/kobocat/commit/7460cc7b3acd179e0ad0a82ae519ea9bb2ad97b4 where `kpi_hook` endpoint must use `v2`.