### PR TITLE
Removed duplicate 'media_file=' argument when building media urls

### DIFF
--- a/onadata/apps/logger/models/attachment.py
+++ b/onadata/apps/logger/models/attachment.py
@@ -74,9 +74,9 @@ class Attachment(models.Model):
         if suffix != "original" and suffix not in settings.THUMB_CONF.keys():
             raise Exception("Invalid image thumbnail")
 
-        return u"{kobocat_url}{media_url}{suffix}?media_file={filename}".format(
+        return u"{kobocat_url}{media_url}{suffix}?{media_file}".format(
             kobocat_url=settings.KOBOCAT_URL,
             media_url=settings.MEDIA_URL,
             suffix=suffix,
-            filename=urlencode({"media_file": self.media_file.name})
+            media_file=urlencode({"media_file": self.media_file.name})
         )

--- a/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
+++ b/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
@@ -85,7 +85,10 @@ class Command(BaseCommand):
             ]},
             {"_attachments": {"$ne": ""}},
             {"_attachments": {"$ne": []}},
-            {"_attachments.download_small_url": {"$exists": False}}
+            {"$or": [
+                {"_attachments.download_url": {"$regex": ".*media_file=media_file.*"}},
+                {"_attachments.download_small_url": {"$exists": False}}
+            ]}
         ]}
 
         if self.__last_id is not None:


### PR DESCRIPTION
Backport of #589 to master branch. Closes #586 