### PR TITLE
Invalidate sessions when changing password

### DIFF
--- a/onadata/apps/main/templates/settings.html
+++ b/onadata/apps/main/templates/settings.html
@@ -6,6 +6,8 @@
   <div class="page-header">
     <h1>{%  trans "Edit User Profile" %}</h1>
   </div>
+  {% comment %}
+  Passwords should *only* be changed from KPI now!
   <div class="row">
     <div class="span6">
       <a class="btn" href="{% url "auth_password_change" %}">{%  trans "change password" %}</a>
@@ -13,6 +15,7 @@
       <br/>
     </div>
   </div>
+  {% endcomment %}
 
   <div class="row">
     <div class="span6">

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -188,6 +188,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     # Django 1.8 removes TransactionMiddleware (was deprecated in 1.6). See:
     # https://docs.djangoproject.com/en/1.6/topics/db/transactions/#transaction-middleware


### PR DESCRIPTION
Also removes the "change password" button since using that will result in KC and KPI having two different password hashes for the same user. Closes #2595.