### PR TITLE
Stitched up the UnicodeDecodeError thrown from parsing ODK stacktrace

### DIFF
--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -488,13 +488,18 @@ def publish_form(callback):
         # ODK validation errors are vanilla errors and it masks a lot of regular
         # errors if we try to catch it so let's catch it, BUT reraise it
         # if we don't see typical ODK validation error messages in it.
-        if u"ODK Validate Errors" not in e.message:
+        try:
+            unicode_message = e.message.decode('utf-8')
+        except UnicodeDecodeError:
+            unicode_message = None
+        if unicode_message is None:
             raise
-
+        if u"ODK Validate Errors" not in unicode_message:
+            raise
         # error in the XLS file; show an error to the user
         return {
             'type': 'alert-error',
-            'text': unicode(e)
+            'text': unicode_message
         }
 
 


### PR DESCRIPTION
Part of the fix for KPI https://github.com/kobotoolbox/kpi/issues/2590.

The error that was being passed to kobocat was giving a UnicodeDecodeError due to a character in the ODK stacktrace that points to where parsing error is for bad XLSForms. 

This change now displays the XLSForm parsing error instead of the one shown in the issue. See https://github.com/kobotoolbox/kpi/pull/2606.