### PR TITLE
Stop sharing cookie for CSRF, but continue…

### DIFF
--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -120,10 +120,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 MIDDLEWARE_CLASSES = ('onadata.koboform.redirect_middleware.ConditionalRedirects', ) + MIDDLEWARE_CLASSES
 
-CSRF_COOKIE_DOMAIN = os.environ.get('CSRF_COOKIE_DOMAIN', None)
-
-if CSRF_COOKIE_DOMAIN:
-    SESSION_COOKIE_DOMAIN = CSRF_COOKIE_DOMAIN
+# Domain must not exclude KPI when sharing sessions
+if os.environ.get('SESSION_COOKIE_DOMAIN'):
+    SESSION_COOKIE_DOMAIN = os.environ['SESSION_COOKIE_DOMAIN']
     SESSION_COOKIE_NAME = 'kobonaut'
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'

--- a/onadata/settings/test_environ.py
+++ b/onadata/settings/test_environ.py
@@ -85,10 +85,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 #MIDDLEWARE_CLASSES = ('onadata.koboform.redirect_middleware.ConditionalRedirects', ) + MIDDLEWARE_CLASSES
 
-CSRF_COOKIE_DOMAIN = os.environ.get('CSRF_COOKIE_DOMAIN', None)
-
-if CSRF_COOKIE_DOMAIN:
-    SESSION_COOKIE_DOMAIN = CSRF_COOKIE_DOMAIN
+# Domain must not exclude KPI when sharing sessions
+if os.environ.get('SESSION_COOKIE_DOMAIN'):
+    SESSION_COOKIE_DOMAIN = os.environ['SESSION_COOKIE_DOMAIN']
     SESSION_COOKIE_NAME = 'kobonaut'
 
 SESSION_SERIALIZER ='django.contrib.sessions.serializers.JSONSerializer'


### PR DESCRIPTION
sharing the session cookie with KPI. Requires accompanying changes in
KPI and kobo-docker.  See kobotoolbox/kpi#2658.

Requires https://github.com/kobotoolbox/kobo-docker/pull/281.