### PR TITLE
Prevent listing all users and public forms

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import (
     DjangoObjectPermissions,
@@ -24,25 +25,32 @@ class ViewDjangoObjectPermissions(DjangoObjectPermissions):
     }
 
 
-class DjangoObjectPermissionsAllowAnon(DjangoObjectPermissions):
-    authenticated_users_only = False
-
-
-class XFormPermissions(DjangoObjectPermissions):
-
-    authenticated_users_only = False
-
+class ObjectPermissionsWithViewRestricted(DjangoObjectPermissions):
+    """
+    The default `perms_map` does not include GET, OPTIONS, or HEAD, meaning
+    anyone can view objects. We override this here to check for `view_…`
+    permissions before allowing objects to be seen. Refer to
+    https://www.django-rest-framework.org/api-guide/permissions/#djangoobjectpermissions
+    """
     def __init__(self, *args, **kwargs):
-
-        # The default `perms_map` does not include GET, OPTIONS, PATCH or HEAD. See
-        # http://www.django-rest-framework.org/api-guide/filtering/#djangoobjectpermissionsfilter
-        self.perms_map = DjangoObjectPermissions.perms_map.copy()
+        super(ObjectPermissionsWithViewRestricted, self).__init__(
+            *args, **kwargs
+        )
+        # Do NOT mutate `perms_map` from the parent class! Doing so will affect
+        # *every* instance of `DjangoObjectPermissions` and all its subclasses
+        self.perms_map = self.perms_map.copy()
         self.perms_map['GET'] = ['%(app_label)s.view_%(model_name)s']
         self.perms_map['OPTIONS'] = ['%(app_label)s.view_%(model_name)s']
         self.perms_map['HEAD'] = ['%(app_label)s.view_%(model_name)s']
-        self.perms_map['PATCH'] = ['%(app_label)s.change_%(model_name)s']
 
-        return super(XFormPermissions, self).__init__(*args, **kwargs)
+        # `PATCH` should already be set properly by DRF, but it used to be
+        # explicitly assigned here as well. Double-check that it's right
+        assert self.perms_map['PATCH'] == ['%(app_label)s.change_%(model_name)s']
+
+    authenticated_users_only = False
+
+
+class XFormPermissions(ObjectPermissionsWithViewRestricted):
 
     def has_permission(self, request, view):
         owner = view.kwargs.get('owner')
@@ -98,13 +106,11 @@ class XFormDataPermissions(XFormPermissions):
         super(XFormDataPermissions, self).__init__(*args, **kwargs)
         # Those who can edit submissions can also delete them, following the
         # behavior of `onadata.apps.main.views.delete_data`
-        self.perms_map = XFormPermissions.perms_map.copy()
+        self.perms_map = self.perms_map.copy()
         self.perms_map['DELETE'] = ['%(app_label)s.' + CAN_CHANGE_XFORM]
 
 
-class UserProfilePermissions(DjangoObjectPermissions):
-
-    authenticated_users_only = False
+class UserProfilePermissions(ObjectPermissionsWithViewRestricted):
 
     def has_permission(self, request, view):
         # allow anonymous users to create new profiles
@@ -202,7 +208,7 @@ class NoteObjectPermissions(DjangoObjectPermissions):
     authenticated_users_only = False
 
     def __init__(self, *args, **kwargs):
-        self.perms_map = DjangoObjectPermissions.perms_map.copy()
+        self.perms_map = self.perms_map.copy()
         self.perms_map['GET'] = ['%(app_label)s.view_xform']
         self.perms_map['OPTIONS'] = ['%(app_label)s.view_xform']
         self.perms_map['HEAD'] = ['%(app_label)s.view_xform']

--- a/onadata/apps/api/viewsets/user_viewset.py
+++ b/onadata/apps/api/viewsets/user_viewset.py
@@ -52,7 +52,7 @@ This endpoint allows you to list and retrieve user's first and last names.
 """
     queryset = User.objects.exclude(pk=settings.ANONYMOUS_USER_ID)
     serializer_class = UserSerializer
-    permission_classes = [permissions.DjangoObjectPermissionsAllowAnon]
+    permission_classes = [permissions.ObjectPermissionsWithViewRestricted]
 
     # This is NOT DRF lookup_field. DRF lookup_field is only located on
     # seralizers and is deprecated and replaced by Meta.extra_kwargs['url']['lookup field']


### PR DESCRIPTION
Closes #616. This essentially backports e62a4c9a and 6c250dd2.

NB: the current permissions system makes detail views for
`/api/v1/users` and `/api/v1/profiles` useless to anyone except
superusers; they should probably be removed. See #117.