### PR TITLE
Remove calls to MongoDB `fsync`

### DIFF
--- a/onadata/apps/viewer/management/commands/remongo.py
+++ b/onadata/apps/viewer/management/commands/remongo.py
@@ -52,9 +52,6 @@ class Command(BaseCommand):
                 else:
                     print("\033[91m[ERROR] Could not parse instance {}\033[0m".format(pi.instance.uuid))
 
-                if (i % 1000) == 0:
-                    print 'Updated %d records, flushing MongoDB...' % i
-                    settings.MONGO_CONNECTION.admin.command({'fsync': 1})
             start = start + batchsize
             end = min(record_count, start + batchsize)
         # add indexes after writing so the writing operation above is not

--- a/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
+++ b/onadata/apps/viewer/management/commands/rewrite_attachments_urls_in_mongo.py
@@ -70,7 +70,6 @@ class Command(BaseCommand):
                     sys.stdout.write(progress)
                     sys.stdout.flush()
 
-                settings.MONGO_CONNECTION.admin.command({'fsync': 1})
                 cursor = self.__get_data()
             else:
                 stop = True

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -651,17 +651,9 @@ def update_mongo_for_xform(xform, only_update_missing=True):
         else:
             done += 1
 
-        # if 1000 records are done, flush mongo
-        if (done > 0 and done % 1000) == 0:
-            sys.stdout.write(
-                'Updated %d records, flushing MongoDB...\n' % done)
-            settings.MONGO_CONNECTION.admin.command({'fsync': 1})
-
         progress = "\r%.2f %% done..." % ((float(done) / float(total)) * 100)
         sys.stdout.write(progress)
         sys.stdout.flush()
-    # flush mongo again when done
-    settings.MONGO_CONNECTION.admin.command({'fsync': 1})
     sys.stdout.write(
         "\nUpdated %s\n------------------------------------------\n"
         % xform.id_string)


### PR DESCRIPTION
which is not available in all environments. Closes #627. Closes kobotoolbox/kobo-docker#293.