### PR TITLE
Listen on port 8001 with uWSGI and `EXPOSE` that

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,10 @@ RUN rm -rf "${KOBOCAT_SRC_DIR}"
 COPY . "${KOBOCAT_SRC_DIR}"
 
 # Prepare for execution.
-RUN mkdir -p /etc/service/uwsgi && \
+# TODO: Remove the wrong port warning and related files, say, at the start of 2021 (see kobotoolbox/kobo-docker#301)
+RUN mkdir -p /etc/service/uwsgi_wrong_port_warning && \
+    cp "${KOBOCAT_SRC_DIR}/docker/run_uwsgi_wrong_port_warning.bash" /etc/service/uwsgi_wrong_port_warning/run && \
+    mkdir -p /etc/service/uwsgi && \
     cp "${KOBOCAT_SRC_DIR}/docker/run_uwsgi.bash" /etc/service/uwsgi/run && \
     mkdir -p /etc/service/celery && \
     ln -s "${KOBOCAT_SRC_DIR}/docker/run_celery.bash" /etc/service/celery/run && \
@@ -62,4 +65,5 @@ RUN echo 'source /etc/profile' >> /root/.bashrc
 
 WORKDIR "${KOBOCAT_SRC_DIR}"
 
-EXPOSE 8000
+# TODO: Remove port 8000, say, at the start of 2021 (see kobotoolbox/kobo-docker#301 and wrong port warning above)
+EXPOSE 8001 8000

--- a/docker/dev_wrong_port_warning.py
+++ b/docker/dev_wrong_port_warning.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+"""
+Per kobotoolbox/kobo-docker#301, we have changed the uWSGI port to 8001. This
+provides a helpful message to anyone still trying to use port 8000
+"""
+
+import BaseHTTPServer
+import sys
+
+class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(503)
+        self.end_headers()
+        self.wfile.write(
+            'Your development environment is trying to connect to the KoBoCAT '
+            'container on port 8000 instead of 8001. Please change this. See '
+            'https://github.com/kobotoolbox/kobo-docker/issues/301 '
+            'for more details.'
+        )
+
+server_address = ('', int(sys.argv[1]))
+httpd = BaseHTTPServer.HTTPServer(server_address, Handler)
+httpd.serve_forever()

--- a/docker/run_uwsgi.bash
+++ b/docker/run_uwsgi.bash
@@ -18,5 +18,5 @@ else
     echo 'Running `kobocat` container with `runserver_plus` debugging application server.'
     cd "${KOBOCAT_SRC_DIR}"
     pip install werkzeug==0.16.0 ipython
-    exec python manage.py runserver_plus 0:8000
+    exec python manage.py runserver_plus 0:8001
 fi

--- a/docker/run_uwsgi_wrong_port_warning.bash
+++ b/docker/run_uwsgi_wrong_port_warning.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+source /etc/profile
+
+# Per kobotoolbox/kobo-docker#301, we have changed the uWSGI port to 8001. This
+# provides a helpful message to anyone still trying to use port 8000
+
+if [[ "${KOBOCAT_WEB_SERVER,,}" == "uwsgi" ]]
+then
+    exec /usr/local/bin/uwsgi --uid "${UWSGI_USER}" --socket :8000 --wsgi-file "${KOBOCAT_SRC_DIR}/docker/wrong_port_warning.wsgi"
+else
+    exec "${KOBOCAT_SRC_DIR}/docker/dev_wrong_port_warning.py" 8000
+fi

--- a/docker/wrong_port_warning.wsgi
+++ b/docker/wrong_port_warning.wsgi
@@ -1,0 +1,23 @@
+# Per kobotoolbox/kobo-docker#301, we have changed the uWSGI port to 8001. This
+# provides a helpful message to anyone still trying to use port 8000.
+# Based upon
+# https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html#the-first-wsgi-application
+
+html_response = b'''
+<html>
+<head><title>System configuration error</title></head>
+<body>
+<h1>System configuration error</h1>
+<p>Please contact the administrator of this server.</p>
+<p style="border: 0.1em solid black; padding: 0.5em">If you are the
+administrator of this server: KoBoCAT received this request on port 8000, when
+8001 should have been used. Please see
+<a href="https://github.com/kobotoolbox/kobo-docker/issues/301">
+https://github.com/kobotoolbox/kobo-docker/issues/301</a> for more
+information.</p>
+<p>Thanks for using KoBoToolbox.</p></body></html>
+'''
+
+def application(env, start_response):
+    start_response('503 Service Unavailable', [('Content-Type','text/html')])
+    return [html_response]


### PR DESCRIPTION
…instead of 8000. Part of kobotoolbox/kobo-docker#301. Includes warning
for anyone that attempts to connect on 8000, the old port.

https://github.com/kobotoolbox/kobo-docker/pull/302 should be merged after this (and after completing the other steps listed in its description).