### PR TITLE
Removed old check for ziggy

### DIFF
--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -197,9 +197,6 @@ class ParsedInstance(models.Model):
 
         if username and id_string:
             query.update(cls.get_base_query(username, id_string))
-            # check if query contains and _id and if its a valid ObjectID
-            if '_uuid' in query and ObjectId.is_valid(query['_uuid']):
-                query['_uuid'] = ObjectId(query['_uuid'])
 
         if hide_deleted:
             # display only active elements


### PR DESCRIPTION
Same reasoning as kobotoolbox/kpi#2780 ( but for `kobocat/kobokitten-remove-ui-CUD-actions-unicode`):

> Removes old check for ObjectId that is not needed anymore:
> 
> Ziggy is dead, so f2his2.
> 
> From this flowdock thread.
> https://www.flowdock.com/app/kobotoolbox/kobo/threads/JWNKW7LKXfzfCpNZpgb9i6lFPWq