### PR TITLE
Make internal KC calls from editing submissions always use public url

### DIFF
--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -732,7 +732,7 @@ data (instance/submission per row)
     @detail_route(methods=['GET'])
     def enketo(self, request, **kwargs):
         self.object = self.get_object()
-        form_url = _get_form_url(request, self.object.user.username)
+        form_url = _get_form_url(self.object.user.username)
 
         data = {'message': _("Enketo not properly configured.")}
         http_status = status.HTTP_400_BAD_REQUEST

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -485,7 +485,7 @@ def enter_data(request, username, id_string):
     if not has_edit_permission(xform, owner, request):
         return HttpResponseForbidden(_('Not shared.'))
 
-    form_url = _get_form_url(request, username, settings.ENKETO_PROTOCOL)
+    form_url = _get_form_url(username)
 
     try:
         url = enketo_url(form_url, xform.id_string)
@@ -540,7 +540,7 @@ def edit_data(request, username, id_string, data_id):
                 'username': username,
                 'id_string': id_string}
         ) + "#/" + str(instance.id))
-    form_url = _get_form_url(request, username, settings.ENKETO_PROTOCOL)
+    form_url = _get_form_url(username)
 
     try:
         url = enketo_url(

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -244,21 +244,10 @@ def _get_form_url(request, username, protocol='https'):
         http_host = settings.TEST_HTTP_HOST
         username = settings.TEST_USERNAME
     else:
-        http_host = request.get_host()
+        # Always use a public url to prevent Enketo SSRF from blocking request
+        http_host = settings.KOBOCAT_URL
 
-    # In case INTERNAL_DOMAIN_NAME is equal to PUBLIC_DOMAIN_NAME,
-    # configuration doesn't use docker internal network.
-    # Don't overwrite `protocol.
-    is_call_internal = settings.KOBOCAT_INTERNAL_HOSTNAME == http_host and \
-                       settings.KOBOCAT_PUBLIC_HOSTNAME != http_host
-
-    # Make sure protocol is enforced to `http` when calling `kc` internally
-
-    # Test: Use public url only
-    http_host = settings.KOBOCAT_URL
-
-    # KOBOCAT_URL already has the protocol
-    #protocol = "http" if is_call_internal else protocol
+    # Internal requests use the public url, KOBOCAT_URL already has the protocol
     return '%s/%s' % (http_host, username)
 
 

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -253,6 +253,9 @@ def _get_form_url(request, username, protocol='https'):
                        settings.KOBOCAT_PUBLIC_HOSTNAME != http_host
 
     # Make sure protocol is enforced to `http` when calling `kc` internally
+
+    # Test: Use public url only
+    http_host = settings.KOBOCAT_URL
     protocol = "http" if is_call_internal else protocol
 
     return '%s://%s/%s' % (protocol, http_host, username)
@@ -267,4 +270,5 @@ def get_enketo_edit_url(request, instance, return_url):
         form_url, instance.xform.id_string, instance_xml=instance.xml,
         instance_id=instance.uuid, return_url=return_url,
         instance_attachments=instance_attachments)
+    raise Exception(form_url)
     return url

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -239,22 +239,23 @@ def create_attachments_zipfile(attachments, output_file=None):
     return output_file
 
 
-def _get_form_url(request, username, protocol='https'):
+def _get_form_url(username):
     if settings.TESTING_MODE:
-        http_host = settings.TEST_HTTP_HOST
+        http_host = 'http://{}'.format(settings.TEST_HTTP_HOST)
         username = settings.TEST_USERNAME
     else:
         # Always use a public url to prevent Enketo SSRF from blocking request
         http_host = settings.KOBOCAT_URL
 
     # Internal requests use the public url, KOBOCAT_URL already has the protocol
-    return '%s/%s' % (http_host, username)
+    return '{http_host}/{username}'.format(
+        http_host=http_host,
+        username=username
+    )
 
 
 def get_enketo_edit_url(request, instance, return_url):
-    form_url = _get_form_url(request,
-                             instance.xform.user.username,
-                             settings.ENKETO_PROTOCOL)
+    form_url = _get_form_url(instance.xform.user.username)
     instance_attachments = image_urls_dict(instance)
     url = enketo_url(
         form_url, instance.xform.id_string, instance_xml=instance.xml,

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -257,9 +257,9 @@ def _get_form_url(request, username, protocol='https'):
     # Test: Use public url only
     http_host = settings.KOBOCAT_URL
 
-    protocol = "http" if is_call_internal else protocol
-
-    return '%s://%s/%s' % (protocol, http_host, username)
+    # KOBOCAT_URL already has the protocol
+    #protocol = "http" if is_call_internal else protocol
+    return '%s/%s' % (http_host, username)
 
 
 def get_enketo_edit_url(request, instance, return_url):

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -256,6 +256,7 @@ def _get_form_url(request, username, protocol='https'):
 
     # Test: Use public url only
     http_host = settings.KOBOCAT_URL
+
     protocol = "http" if is_call_internal else protocol
 
     return '%s://%s/%s' % (protocol, http_host, username)
@@ -270,5 +271,4 @@ def get_enketo_edit_url(request, instance, return_url):
         form_url, instance.xform.id_string, instance_xml=instance.xml,
         instance_id=instance.uuid, return_url=return_url,
         instance_attachments=instance_attachments)
-    raise Exception(form_url)
     return url

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -121,15 +121,6 @@ KPI_HOOK_ENDPOINT_PATTERN = '/api/v2/assets/{asset_uid}/hook-signal/'
 # All internal communications between containers must be HTTP only.
 ENKETO_PROTOCOL = os.environ.get('ENKETO_PROTOCOL', 'https')
 
-# These 2 variables are needed to detect whether the ENKETO_PROTOCOL should overwritten or not.
-# See method `_get_form_url` in `onadata/libs/utils/viewer_tools.py`
-KOBOCAT_INTERNAL_HOSTNAME = "{}.{}".format(
-    os.environ.get("KOBOCAT_PUBLIC_SUBDOMAIN", "kc"),
-    os.environ.get("INTERNAL_DOMAIN_NAME", "docker.internal"))
-KOBOCAT_PUBLIC_HOSTNAME = "{}.{}".format(
-    os.environ.get("KOBOCAT_PUBLIC_SUBDOMAIN", "kc"),
-    os.environ.get("PUBLIC_DOMAIN_NAME", "kobotoolbox.org"))
-
 # Default value for the `UserProfile.require_auth` attribute. Even though it's
 # set in kc_environ, include it here as well to support legacy installations
 REQUIRE_AUTHENTICATION_TO_SEE_FORMS_AND_SUBMIT_DATA_DEFAULT = False


### PR DESCRIPTION
What's happening (before):

- KPI asks for Enketo Express edit link, it uses KC as a proxy on the private domain name. (e.g. kc.domainname.internal).
- KC POSTs to EE API to get edit link. Among the parameters, KC sends the current domain name
- EE prepares the form in edit mode and create absolute links to media files with the domain it just received.
- All media files are now http://kc.domainname.internal/path.media.file.jpg.
- SSRF blocks them

What happens now:
- KC POSTs to EE API to get edit link. Among the parameters, KC sends the ~~current domain name~~ current public url, e.g, `kc.domainname.org` rather than `*.internal`
- [...]
- SSRF does not block the public url

Some potential caveats:
> @noliveleger Actually, enforce external domain name have some drawbacks too. The request will always go outside the load balancer before coming in again. The latency would be higher (but not a big deal). My main concern, is the outbound data transfer. I'm thinking out loud. It will increase the outbound data transfer. If users edit a lot, it will have a cost (and we know that outbound data transfer is the highest cost on AWS)


Fixes #658 