### PR TITLE
[Python3 and Django2.2 upgrade] Force text messages in OpenRosaResponse

### DIFF
--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -561,7 +561,7 @@ class OpenRosaResponse(BaseOpenRosaResponse):
         self.content = '''<?xml version='1.0' encoding='UTF-8' ?>
 <OpenRosaResponse xmlns="http://openrosa.org/http/response">
         <message nature="">%s</message>
-</OpenRosaResponse>''' % self.content
+</OpenRosaResponse>''' % smart_str(self.content)
 
 
 class OpenRosaResponseNotFound(OpenRosaResponse):


### PR DESCRIPTION
Force OpenRosaResponse message content to be string. In some cases it's prefixed with 'b' caused by the bytestring nature of HttpResponse serialization method.