### PR TITLE
Remove `submission_count_for_today` from API…

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -59,39 +59,6 @@ class TestXFormViewSet(TestAbstractViewSet):
         response = self.view(request)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_submission_count_for_today_in_form_list(self):
-
-        self.publish_xls_form()
-
-        request = self.factory.get('/', **self.extra)
-        response = self.view(request)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('submission_count_for_today', response.data[0].keys())
-        self.assertEqual(response.data[0]['submission_count_for_today'], 0)
-        self.assertEqual(response.data[0]['num_of_submissions'], 0)
-
-        paths = [os.path.join(
-            self.main_directory, 'fixtures', 'transportation',
-            'instances_w_uuid', s, s + '.xml')
-            for s in ['transport_2011-07-25_19-05-36']]
-
-        # instantiate date that is NOT naive; timezone is enabled
-        current_timezone_name = timezone.get_current_timezone_name()
-        current_timezone = pytz.timezone(current_timezone_name)
-        today = datetime.today()
-        current_date = current_timezone.localize(
-            datetime(today.year,
-                     today.month,
-                     today.day))
-        self._make_submission(paths[0], forced_submission_time=current_date)
-        self.assertEqual(self.response.status_code, status.HTTP_201_CREATED)
-
-        request = self.factory.get('/', **self.extra)
-        response = self.view(request)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[0]['submission_count_for_today'], 1)
-        self.assertEqual(response.data[0]['num_of_submissions'], 1)
-
     def test_form_list_anon(self):
         self.publish_xls_form()
         request = self.factory.get('/')

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -222,20 +222,6 @@ class XForm(BaseModel):
         return self.num_of_submissions
     submission_count.short_description = ugettext_lazy("Submission Count")
 
-    @property
-    def submission_count_for_today(self):
-        current_timzone_name = timezone.get_current_timezone_name()
-        current_timezone = pytz.timezone(current_timzone_name)
-        today = datetime.today()
-        current_date = current_timezone.localize(
-            datetime(today.year,
-                     today.month,
-                     today.day))
-        count = self.instances.filter(
-            deleted_at__isnull=True,
-            date_created=current_date).count()
-        return count
-
     def geocoded_submission_count(self):
         """Number of geocoded submissions."""
         return self.instances.filter(deleted_at__isnull=True,

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -19,7 +19,6 @@ class XFormSerializer(serializers.HyperlinkedModelSerializer):
     public = BooleanField(source='shared')
     public_data = BooleanField(source='shared_data')
     require_auth = BooleanField()
-    submission_count_for_today = serializers.ReadOnlyField()
     tags = TagListSerializer(read_only=True)
     title = serializers.CharField(max_length=255)
     url = serializers.HyperlinkedIdentityField(view_name='xform-detail',


### PR DESCRIPTION
Emergency self-merge due to HHI production outages
## Description

Remove `submission_count_for_today` from `/api/v1/forms` because it thrashes the database