### PR TITLE
Integrate view-only submissions endpoint from Enketo

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -102,7 +102,7 @@ class XFormDataPermissions(ObjectPermissionsWithViewRestricted):
         lookup_field = view.lookup_field
         lookup = view.kwargs.get(lookup_field)
         # Allow anonymous users to access access shared data
-        allowed_anonymous_action = ['retrieve']
+        allowed_anonymous_action = ['retrieve', 'enketo']
         if lookup:
             # We need to grant access to anonymous on list endpoint too when
             # a form pk is specified. e.g. `/api/v1/data/{pk}.json

--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -115,7 +115,7 @@ class XFormDataPermissions(ObjectPermissionsWithViewRestricted):
     def has_object_permission(self, request, view, obj):
         # Allow anonymous users to access shared data
         if request.method in SAFE_METHODS and \
-                view.action in ['retrieve', 'list']:
+                view.action in ['retrieve', 'list', 'enketo']:
             if obj.shared_data:
                 return True
 

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -297,6 +297,25 @@ class TestDataViewSet(TestBase):
                 response.data['url'],
                 "https://hmh2a.enketo.formhub.org")
 
+    def test_get_enketo_view_url(self):
+        self._make_submissions()
+        view = DataViewSet.as_view({'get': 'enketo'})
+        request = self.factory.get('/', **self.extra)
+        formid = self.xform.pk
+        dataid = self.xform.instances.all().order_by('id')[0].pk
+
+        request = self.factory.get(
+            '/',
+            data={'return_url': "http://test.io/test_url", 'action': 'view'},
+            **self.extra
+        )
+
+        with HTTMock(enketo_mock):
+            response = view(request, pk=formid, dataid=dataid)
+            self.assertEqual(
+                response.data['url'],
+                "https://hmh2a.enketo.formhub.org")
+
     def test_get_form_public_data(self):
         self._make_submissions()
         view = DataViewSet.as_view({'get': 'list'})

--- a/onadata/apps/api/urls.py
+++ b/onadata/apps/api/urls.py
@@ -91,7 +91,6 @@ class MultiLookupRouter(routers.DefaultRouter):
         for route in self.lookups_routes:
             if route.mapping == {'{httpmethod}': '{methodname}'}:
                 for extra_action in viewset.get_extra_actions():
-                    # FIXME support `url_path` and `url_name` of `@action` decorator
                     methodname = extra_action.__name__
                     mapping = extra_action.mapping
                     detail = extra_action.detail

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import json
+from typing import Union
 
 from django.db.models import Q
 from django.http import Http404
@@ -447,26 +448,26 @@ Delete a specific submission in a form
 
         return serializer_class
 
-    def get_object(self):
-        obj = super().get_object()
+    def get_object(self) -> Union[XForm, Instance]:
+        xform = super().get_object()
         pk_lookup, dataid_lookup = self.lookup_fields
         pk = self.kwargs.get(pk_lookup)
         dataid = self.kwargs.get(dataid_lookup)
 
-        if pk is not None and dataid is not None:
-            try:
-                int(pk)
-            except ValueError:
-                raise ParseError(_("Invalid pk `%(pk)s`" % {'pk': pk}))
-            try:
-                int(dataid)
-            except ValueError:
-                raise ParseError(_("Invalid dataid `%(dataid)s`"
-                                   % {'dataid': dataid}))
+        if pk is None or dataid is None:
+           return  xform
 
-            return get_object_or_404(Instance, pk=dataid, xform__pk=pk)
+        try:
+            int(pk)
+        except ValueError:
+            raise ParseError(_("Invalid pk `%(pk)s`" % {'pk': pk}))
+        try:
+            int(dataid)
+        except ValueError:
+            raise ParseError(_("Invalid dataid `%(dataid)s`"
+                               % {'dataid': dataid}))
 
-        return obj
+        return get_object_or_404(Instance, pk=dataid, xform__pk=pk)
 
     def _get_public_forms_queryset(self):
         return XForm.objects.filter(Q(shared=True) | Q(shared_data=True))
@@ -595,7 +596,7 @@ Delete a specific submission in a form
                 raise PermissionDenied(_("You do not have sufficient permissions."))
 
             try:
-                data["url"] = get_enketo_submission_url(
+                data['url'] = get_enketo_submission_url(
                     request, self.object, return_url, action=action
                 )
             except EnketoError as e:

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -448,6 +448,7 @@ Delete a specific submission in a form
         return serializer_class
 
     def get_object(self):
+        obj = super().get_object()
         pk_lookup, dataid_lookup = self.lookup_fields
         pk = self.kwargs.get(pk_lookup)
         dataid = self.kwargs.get(dataid_lookup)
@@ -465,7 +466,7 @@ Delete a specific submission in a form
 
             return get_object_or_404(Instance, pk=dataid, xform__pk=pk)
 
-        return super().get_object()
+        return obj
 
     def _get_public_forms_queryset(self):
         return XForm.objects.filter(Q(shared=True) | Q(shared_data=True))
@@ -585,7 +586,10 @@ Delete a specific submission in a form
             elif action == 'view':
                 # Allow anonymous access to view-only if the data has been made
                 # public
-                if request.user.is_anonymous and not self.object.xform.shared:
+                if (
+                    request.user.is_anonymous
+                    and not self.object.xform.shared_data
+                ):
                     raise Http404
             else:
                 raise PermissionDenied(_("You do not have sufficient permissions."))

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -170,8 +170,15 @@ def get_client_ip(request):
     return ip
 
 
-def enketo_url(form_url, id_string, instance_xml=None,
-               instance_id=None, return_url=None, instance_attachments=None):
+def enketo_url(
+    form_url,
+    id_string,
+    instance_xml=None,
+    instance_id=None,
+    return_url=None,
+    instance_attachments=None,
+    action=None,
+):
 
     if not hasattr(settings, 'ENKETO_URL')\
             and not hasattr(settings, 'ENKETO_API_SURVEY_PATH'):
@@ -198,6 +205,12 @@ def enketo_url(form_url, id_string, instance_xml=None,
             values.update({
                 'instance_attachments[' + key + ']': value
             })
+
+    # The Ekento view-only endpoint differs to the edit by the addition of /view
+    # as shown in the docs: https://apidocs.enketo.org/v2#/post-instance-view
+    if action == 'view':
+        url = '{}/view'.format(url)
+
     req = requests.post(url, data=values,
                         auth=(settings.ENKETO_API_TOKEN, ''), verify=False)
 
@@ -209,6 +222,8 @@ def enketo_url(form_url, id_string, instance_xml=None,
         else:
             if 'edit_url' in response:
                 return response['edit_url']
+            elif 'view_url' in response:
+                return response['view_url']
             if settings.ENKETO_OFFLINE_SURVEYS and ('offline_url' in response):
                 return response['offline_url']
             if 'url' in response:
@@ -256,11 +271,11 @@ def _get_form_url(username):
     )
 
 
-def get_enketo_edit_url(request, instance, return_url):
+def get_enketo_submission_url(request, instance, return_url, action=None):
     form_url = _get_form_url(instance.xform.user.username)
     instance_attachments = image_urls_dict(instance)
     url = enketo_url(
         form_url, instance.xform.id_string, instance_xml=instance.xml,
         instance_id=instance.uuid, return_url=return_url,
-        instance_attachments=instance_attachments)
+        instance_attachments=instance_attachments, action=action)
     return url

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -206,7 +206,7 @@ def enketo_url(
                 'instance_attachments[' + key + ']': value
             })
 
-    # The Ekento view-only endpoint differs to the edit by the addition of /view
+    # The Enketo view-only endpoint differs to the edit by the addition of /view
     # as shown in the docs: https://apidocs.enketo.org/v2#/post-instance-view
     if action == 'view':
         url = '{}/view'.format(url)


### PR DESCRIPTION
Implementing the [community requested](https://community.kobotoolbox.org/t/ability-to-view-completed-submissions-in-enketo-and-ideally-pdf-them/15457) feature for view-only submissions (excluding the PDF option for the moment).

The current `kpi` endpoint only returns a URL for editing purposes, accessed with a `GET` request to:

```
https://{kpi_url}/api/v2/assets/{asset_uid}/data/{submission_id}/edit/?return_url=false
```

A view-only URL can now be returned when accessing the new `kpi` endpoint:

```
https://{kpi_url}/api/v2/assets/{asset_uid}/data/{submission_id}/enketo/view/
```

And the edit URL can now be returned when accessing the updated endpoint at:

```
https://{kpi_url}/api/v2/assets/{asset_uid}/data/{submission_id}/enketo/edit/?return_url=false
```

## Description

The changes will integrate with KPI's new `/enketo/<action>` endpoint, returning a view-only submission URL when a `GET` request is made to `/enketo/view/`.

## Related issues
closes #671 
part of kobotoolbox/kpi#2993