### PR TITLE
Proceed if empty instance found when syncing Mongo

### DIFF
--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -644,11 +644,21 @@ def update_mongo_for_xform(xform, only_update_missing=True):
     done = 0
     for id_, instance in instances.items():
         (pi, created) = ParsedInstance.objects.get_or_create(instance=instance)
-        if not pi.save(asynchronous=False):
-            print("\033[91m[ERROR] - Instance #{}/uuid:{} - Could not save the parsed instance\033[0m".format(
-                id_, instance.uuid))
+        try:
+            save_success = pi.save(asynchronous=False)
+        except InstanceEmptyError:
+            print(
+                "\033[91m[WARNING] - Skipping Instance #{}/uuid:{} because "
+                "it is empty\033[0m".format(id_, instance.uuid)
+            )
         else:
-            done += 1
+            if not save_success:
+                print(
+                    "\033[91m[ERROR] - Instance #{}/uuid:{} - Could not save "
+                    "the parsed instance\033[0m".format(id_, instance.uuid)
+                )
+            else:
+                done += 1
 
         progress = "\r%.2f %% done..." % ((float(done) / float(total)) * 100)
         sys.stdout.write(progress)


### PR DESCRIPTION
…instead of crashing with an unhandled exception. This only affects bulk MongoDB resynchronization, since only `mongo_sync_status()` calls `update_mongo_for_xform()`.

## Description

Prevent a system administration command, `./manage.py sync_mongo --remongo`, from failing if it encounters an empty submission