### PR TITLE
Add version information to form list

### DIFF
--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals, print_function, division, absolute_import
 
+import json
+
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
@@ -82,7 +84,12 @@ class XFormListSerializer(serializers.Serializer):
     manifestUrl = serializers.SerializerMethodField('get_manifest_url')
 
     def get_version(self, obj):
-        return None
+        # Returns version data
+        # The data returned may vary depending on the contents of the 
+        # version field in the settings of the XLS file when the asset was
+        # created or updated
+        obj_json = json.loads(obj.json)
+        return obj_json.get('version')
 
     @check_obj
     def get_hash(self, obj):

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -8,7 +8,7 @@ ipdb
 ipython
 shell_command
 statsd
-twill==2.0.3
+twill
 Werkzeug
 sqlparse
 pytest==3.10

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -8,7 +8,7 @@ ipdb
 ipython
 shell_command
 statsd
-twill
+twill==2.0.3
 Werkzeug
 sqlparse
 pytest==3.10


### PR DESCRIPTION
1. [N/A] If you've added code that should be tested, add tests
2. [N/A] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed our coding style
5. [x] Write a description of your work suitable for publishing on our forum
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

The `<version>` tag in the `formList` will now show the version information based on what was sent to KoBoCat from KPI at the time the form was created or updated. What is returned will depend on when the form was last updated. The possible items that can be returned include the UID, the version number and date, or it may return nothing.

To update this field:
- Login to KPI
- Go to the form you wish to display the version number and date
- Edit the form - **Note:** it is not required to change anything within the form
- Press save
- Redeploy the form

## Related issues

Fixes #674 
Related to kobotoolbox/kpi#3046