### PR TITLE
Add guidance and redirect links to KPI for legacy form and data views

### DIFF
--- a/kobocat-template/templates/base.html
+++ b/kobocat-template/templates/base.html
@@ -1,4 +1,6 @@
 {% load static %}
+{% with legacy_learn_more_url="https://community.kobotoolbox.org/t/changes-to-legacy-interface-self-serve-migration-feature-into-the-new-interface/18108" %}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -57,15 +59,6 @@
     {% if not user.is_authenticated %}
 
         <body>
-            {% block not_auth %}
-                <div class="legacy-warning">
-                    <div class="container">
-                        We no longer recommend using the legacy interface. Please access all our new features in the <a
-                            href="{{ koboform_url }}">regular interface</a> (new map, table, reports, labeled data exports, etc.).
-                    </div>
-                </div>
-            {% endblock %}
-
             <header class="header-bar">
                 <div class="container__wide">
                     <span class="header-bar__top-logo pull-right"></span>
@@ -145,3 +138,5 @@
 </body>
 {% endblock %}
 </html>
+
+{% endwith %} {# legacy_learn_more_url #}

--- a/kobocat-template/templates/legacy_banner.html
+++ b/kobocat-template/templates/legacy_banner.html
@@ -1,8 +1,5 @@
 {% load i18n %} 
-
 {% load static %} 
-
-{% with learn_more_url="https://community.kobotoolbox.org/t/changes-to-legacy-interface-self-serve-migration-feature-into-the-new-interface/18108" %}
 
 <script type="text/javascript">
   (function () {
@@ -319,7 +316,7 @@ THE POPUP
         <a
           id="legacy-banner-popup-learn"
           class="legacy-banner__button legacy-banner__button--borderless"
-          href="{{ learn_more_url }}"
+          href="{{ legacy_learn_more_url }}"
           target="_blank"
         >
           {% trans "Learn more" %}
@@ -385,5 +382,3 @@ THE BANNER
     </p>
   </section>
 </div>
-
-{% endwith %}

--- a/kobocat-template/templates/outdated_data_view.html
+++ b/kobocat-template/templates/outdated_data_view.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% load static %}
+
+
+{% block before-content %}
+{% load i18n %}
+
+<div class="sub-header-bar">
+  <div class="container__wide">
+    <a class="sub-header__back" href="{% url "show_form" xform.user.username xform.id_string %}"><i class="fa fa-chevron-left"></i> {% trans "Return to" %} {{ xform.title }}</a>
+  </div>
+</div>
+
+<header class="data-page__header">
+</header>
+
+{% endblock %}
+
+{% block content %}
+{% load i18n %}
+
+<section>
+  {% include "outdated_link_guidance.html" %}
+</section>
+{% endblock %}

--- a/kobocat-template/templates/outdated_link_guidance.html
+++ b/kobocat-template/templates/outdated_link_guidance.html
@@ -1,0 +1,59 @@
+{% load i18n %}
+<style>
+  #kpi_url_box {
+    border: 2px solid #E9EDF0;
+    display: inline-block;
+    font-size: larger;
+    margin: 0;
+    padding: 0.5em;
+  }
+  #kpi_url_clipboard {
+    cursor: pointer;
+    margin-left: 0.75em;
+  }
+</style>
+<script>
+  function copyKpiUrl() {
+    var el = document.getElementById("kpi_url_clipboard");
+    if (!navigator.clipboard) {
+      el.outerHTML = "<i>{% trans "sorry, browser did not allow copying to clipboard" %}";
+    } else {
+      navigator.clipboard.writeText("{{ kpi_url }}").then(
+        function() {
+          el.innerText = "{% trans "copied to clipboard!" %}";
+          el.className = "";
+        }
+      );
+    }
+  }
+</script>
+<div>
+  <h2>⚠ {% trans "Outdated Link" %}</h2>
+  {% if not kpi_url %}
+    {% if user == xform.user %}
+      <p>
+        {% trans "Many features cannot be accessed at this outdated address." %}
+        <a href="/">{% trans "Please click here to synchronize your forms." %}</a>
+      </p>
+    {% else %}
+      <p>
+        {% trans "Many features cannot be accessed at this outdated address." %}
+        {% trans "Please ask the owner to log into their account and synchronize their forms." %}
+      </p>
+    {% endif %}
+  {% else %}
+    <p>
+      {% trans "Many features cannot be accessed at this outdated address." %}
+      {% trans "Please use the following instead:" %}
+    </p>
+    <p id="kpi_url_box">
+      <a href="{{ kpi_url }}">{{ kpi_url }}</a>
+      <i id="kpi_url_clipboard" class="fa fa-fw fa-clipboard" onclick="copyKpiUrl()"></i>
+    </p>
+  {% endif %}
+  <p>
+    <a href="{{ legacy_learn_more_url }}" target="_blank">
+      {% trans "To learn more, please click here." %}
+    </a>
+  </p>
+</div>

--- a/kobocat-template/templates/show.html
+++ b/kobocat-template/templates/show.html
@@ -37,6 +37,10 @@
     {% load i18n %}
 
     <!-- NEW SINGLE PROJECT VIEW -->
+
+    {% include "outdated_link_guidance.html" %}
+    <hr>
+
     <div class="dashboard__left">
         <div class="dashboard__submissions">
             <h2 class="dashboard__group-label">

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -2,7 +2,7 @@
 from django.conf import settings
 from django.contrib import admin
 
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 
@@ -26,7 +26,10 @@ from onadata.apps.main.views import (
     delete_metadata,
     download_metadata,
     download_media_data,
-    show_form_settings
+    show_form_settings,
+
+    # views that now exist only in KPI
+    make_kpi_data_redirect_view,
 )
 
 # exporting stuff
@@ -111,6 +114,21 @@ urlpatterns = [
             r'(?P<data_id>\d+)', download_media_data, name='download_media_data'),
     re_path(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)/form_settings$',
             show_form_settings, name='show_form_settings'),
+    path(
+        '<str:username>/reports/<str:id_string>/export.html',
+        make_kpi_data_redirect_view('table'),
+        name='redirect_view_data_in_table_to_kpi',
+    ),
+    path(
+        '<str:username>/reports/<str:id_string>/digest.html',
+        make_kpi_data_redirect_view('report'),
+        name='redirect_analyze_data_to_kpi',
+    ),
+    path(
+        '<str:username>/forms/<str:id_string>/map',
+        make_kpi_data_redirect_view('map'),
+        name='redirect_map_to_kpi',
+    ),
 
     # briefcase api urls
     re_path(r"^(?P<username>\w+)/view/submissionList$",

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -37,6 +37,7 @@ from onadata.libs.utils.user_auth import (
     add_cors_headers,
     check_and_set_user_and_form,
     get_xform_and_perms,
+    has_permission,
     helper_auth_helper,
     set_profile_data,
 )
@@ -181,6 +182,11 @@ def show(request, username=None, id_string=None, uuid=None):
 
     if is_owner:
         data['media_form'] = MediaForm()
+
+    if xform.kpi_asset_uid:
+        data['kpi_url'] = (
+            f'{settings.KOBOFORM_URL}/#/forms/{xform.kpi_asset_uid}'
+        )
 
     return render(request, "show.html", data)
 
@@ -535,3 +541,19 @@ def _get_migrate_url(username):
     return '{kf_url}/api/v2/users/{username}/migrate/'.format(
         kf_url=settings.KOBOFORM_URL, username=username
     )
+
+def make_kpi_data_redirect_view(kpi_data_route):
+    def view_func(request, username, id_string):
+        owner = get_object_or_404(User, username__iexact=username)
+        xform = get_object_or_404(XForm, id_string__exact=id_string, user=owner)
+        if not has_permission(xform, owner, request):
+            return HttpResponseForbidden(_('Not shared.'))
+        data = {'xform': xform}
+        if xform.kpi_asset_uid:
+            data['kpi_url'] = (
+                f'{settings.KOBOFORM_URL}/#/forms/{xform.kpi_asset_uid}/data/'
+                f'{kpi_data_route}'
+            )
+        return render(request, 'outdated_data_view.html', data)
+
+    return view_func


### PR DESCRIPTION
## Description

This will hopefully help ease the transition away from removed features of KoBoCAT's legacy UI, especially for those arriving via anonymous-access links.

## Developer Notes

Copying to the clipboard with JavaScript does not work in a non-"secure context", e.g. one without HTTPS. Chrome's `chrome://flags/#unsafely-treat-insecure-origin-as-secure` can help you test locally, but I haven't found anything equivalent in Firefox.