### PR TITLE
Fix local ZIP exports

### DIFF
--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -436,6 +436,7 @@ def safe_create_instance(username, xml_file, media_files, uuid, request):
 
 
 def report_exception(subject, info, exc_info=None):
+    # TODO: replace with standard logging (i.e. `import logging`)
     if exc_info:
         cls, err = exc_info[:2]
         message = _("Exception in request:"


### PR DESCRIPTION
(by _not_ crashing when `FileSystemStorage` does not allow overwriting the
`seek` method on an export file)

Fixes an issue caused by a2dbb91ce6742e0d33b0a2538f7a8b28d855a0fb

See discussion at
https://community.kobotoolbox.org/t/unable-to-download-zipped-media-files/21142/9?u=jnm