### PR TITLE
fix(migrations): remove sms_id_string occurrence causing faulty history.

### DIFF
--- a/onadata/apps/logger/migrations/0001_initial.py
+++ b/onadata/apps/logger/migrations/0001_initial.py
@@ -84,7 +84,6 @@ class Migration(migrations.Migration):
                 ('downloadable', models.BooleanField(default=True)),
                 ('allows_sms', models.BooleanField(default=False)),
                 ('encrypted', models.BooleanField(default=False)),
-                ('sms_id_string', models.SlugField(default='', verbose_name='SMS ID', max_length=100, editable=False)),
                 ('id_string', models.SlugField(verbose_name='ID', max_length=100, editable=False)),
                 ('title', models.CharField(max_length=255, editable=False)),
                 ('date_created', models.DateTimeField(auto_now_add=True)),
@@ -146,9 +145,5 @@ class Migration(migrations.Migration):
             model_name='attachment',
             name='instance',
             field=models.ForeignKey(related_name='attachments', to='logger.Instance', on_delete=models.CASCADE),
-        ),
-        migrations.AlterUniqueTogether(
-            name='xform',
-            unique_together=set([('user', 'id_string'), ('user', 'sms_id_string')]),
         ),
     ]

--- a/onadata/apps/logger/migrations/0001_initial.py
+++ b/onadata/apps/logger/migrations/0001_initial.py
@@ -146,4 +146,8 @@ class Migration(migrations.Migration):
             name='instance',
             field=models.ForeignKey(related_name='attachments', to='logger.Instance', on_delete=models.CASCADE),
         ),
+        migrations.AlterUniqueTogether(
+            name='xform',
+            unique_together=set([('user', 'id_string')]),
+        ),
     ]

--- a/onadata/apps/logger/migrations/0017_remove_xform_sms.py
+++ b/onadata/apps/logger/migrations/0017_remove_xform_sms.py
@@ -37,9 +37,3 @@ class Migration(migrations.Migration):
             name='allows_sms',
         )
     )
-    operations.append(
-        migrations.RemoveField(
-            model_name='xform',
-            name='sms_id_string',
-        )
-    )


### PR DESCRIPTION
For new comers, when applying migrations we'll be alerted by the error below which is caused by a faulty history regarding the `sms_id_string` field

```
django.core.exceptions.FieldDoesNotExist: XForm has no field named 'sms_id_string'
```

## Steps to Reproduce
1. Clone the project
2. Make migrations ( python manage.py makemigrations) -- Without this step everything works normally 
3. Apply the migration --> KeyError: 'sms_id_string'

### Fixes issue
https://github.com/kobotoolbox/kobocat/issues/763
