### PR TITLE
Update transifex-client for Python 3.9

### DIFF
--- a/dependencies/pip/dev.txt
+++ b/dependencies/pip/dev.txt
@@ -287,7 +287,7 @@ traceback2==1.4.0
     # via unittest2
 traitlets==4.3.3
     # via ipython
-transifex-client==0.13.11
+transifex-client==0.14.3
     # via -r dependencies/pip/requirements.in
 unicodecsv==0.14.1
     # via

--- a/dependencies/pip/prod.txt
+++ b/dependencies/pip/prod.txt
@@ -216,7 +216,7 @@ tlslite-ng==0.7.5
     # via gdata-python3
 traceback2==1.4.0
     # via unittest2
-transifex-client==0.13.11
+transifex-client==0.14.3
     # via -r dependencies/pip/requirements.in
 unicodecsv==0.14.1
     # via

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -216,7 +216,7 @@ tlslite-ng==0.7.5
     # via gdata-python3
 traceback2==1.4.0
     # via unittest2
-transifex-client==0.13.11
+transifex-client==0.14.3
     # via -r dependencies/pip/requirements.in
 unicodecsv==0.14.1
     # via


### PR DESCRIPTION
I don't think anything should change about the way we use the client, but I haven't tested it.
See also: https://github.com/transifex/transifex-client/commit/e679ee546e4ceb80150b523748167f9df446bb2d