### PR TITLE
Use base image compatible with s390x architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs10
+# TODO: use a multi-architecture base image
+# FROM nikolaik/python-nodejs:python3.8-nodejs10
+FROM s390x/node:16-bullseye
 
 # Declare environment variables
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dependencies/pip/dev.txt
+++ b/dependencies/pip/dev.txt
@@ -10,6 +10,8 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/pyxform@s390x#egg=pyxform
+    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@755efe16694273ce66060a51e04f973dc034ca4e#egg=ssrf_protect
     # via -r dependencies/pip/requirements.in
 amqp==2.6.0
@@ -123,6 +125,8 @@ elaphe3==0.2.0
     # via -r dependencies/pip/requirements.in
 et-xmlfile==1.0.1
     # via openpyxl
+excelrd==2.0.3
+    # via pyxform
 formencode==1.3.1
     # via pyxform
 future==0.18.2
@@ -236,8 +240,6 @@ pytz==2020.1
     #   django
     #   django-timezone-field
     #   pandas
-pyxform==1.5.1
-    # via -r dependencies/pip/requirements.in
 redis==3.5.3
     # via
     #   -r dependencies/pip/requirements.in
@@ -250,7 +252,7 @@ requests==2.24.0
     #   transifex-client
 s3transfer==0.3.3
     # via boto3
-https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip#egg=savreaderwriter
+savreaderwriter @ https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip
     # via -r dependencies/pip/requirements.in
 sentinels==1.0.0
     # via mongomock
@@ -312,9 +314,7 @@ wcwidth==0.2.5
 werkzeug==1.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   pyxform
+    # via -r dependencies/pip/requirements.in
 xlwt==1.3.0
     # via -r dependencies/pip/requirements.in
 

--- a/dependencies/pip/prod.txt
+++ b/dependencies/pip/prod.txt
@@ -10,6 +10,8 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/pyxform@s390x#egg=pyxform
+    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@755efe16694273ce66060a51e04f973dc034ca4e#egg=ssrf_protect
     # via -r dependencies/pip/requirements.in
 amqp==2.6.0
@@ -113,6 +115,8 @@ elaphe3==0.2.0
     # via -r dependencies/pip/requirements.in
 et-xmlfile==1.0.1
     # via openpyxl
+excelrd==2.0.3
+    # via pyxform
 formencode==1.3.1
     # via pyxform
 future==0.18.2
@@ -177,8 +181,6 @@ pytz==2020.1
     #   django
     #   django-timezone-field
     #   pandas
-pyxform==1.5.1
-    # via -r dependencies/pip/requirements.in
 redis==3.5.3
     # via
     #   -r dependencies/pip/requirements.in
@@ -190,7 +192,7 @@ requests==2.24.0
     #   transifex-client
 s3transfer==0.3.3
     # via boto3
-https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip#egg=savreaderwriter
+savreaderwriter @ https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip
     # via -r dependencies/pip/requirements.in
 sentry-sdk==0.16.5
     # via -r dependencies/pip/requirements.in
@@ -239,8 +241,6 @@ vine==1.3.0
 werkzeug==2.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   pyxform
+    # via -r dependencies/pip/requirements.in
 xlwt==1.3.0
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -5,6 +5,7 @@
 # Also, python-digest is an unlisted dependency thereof.
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest
+-e git+https://github.com/jnm/pyxform@s390x#egg=pyxform
 
 # spss
 https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip#egg=savreaderwriter
@@ -29,7 +30,6 @@ Pillow
 psycopg2-binary
 pymongo
 lxml
-pyxform
 django-reversion<3.0.2
 xlrd
 xlwt

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -10,6 +10,8 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/pyxform@s390x#egg=pyxform
+    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@755efe16694273ce66060a51e04f973dc034ca4e#egg=ssrf_protect
     # via -r dependencies/pip/requirements.in
 amqp==2.6.0
@@ -113,6 +115,8 @@ elaphe3==0.2.0
     # via -r dependencies/pip/requirements.in
 et-xmlfile==1.0.1
     # via openpyxl
+excelrd==2.0.3
+    # via pyxform
 formencode==1.3.1
     # via pyxform
 future==0.18.2
@@ -177,8 +181,6 @@ pytz==2020.1
     #   django
     #   django-timezone-field
     #   pandas
-pyxform==1.5.1
-    # via -r dependencies/pip/requirements.in
 redis==3.5.3
     # via
     #   -r dependencies/pip/requirements.in
@@ -190,7 +192,7 @@ requests==2.24.0
     #   transifex-client
 s3transfer==0.3.3
     # via boto3
-https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip#egg=savreaderwriter
+savreaderwriter @ https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip
     # via -r dependencies/pip/requirements.in
 sentry-sdk==0.16.5
     # via -r dependencies/pip/requirements.in
@@ -237,8 +239,6 @@ vine==1.3.0
 werkzeug==2.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   pyxform
+    # via -r dependencies/pip/requirements.in
 xlwt==1.3.0
     # via -r dependencies/pip/requirements.in


### PR DESCRIPTION
Sometimes it's easier to show a draft PR than write an issue. This can't be merged because it simply swaps the standard base image out for one that's built for s390x. The work will be to identify a proper multi-architecture solution that can replace both.