### PR TITLE
Fix media list endpoint

### DIFF
--- a/onadata/libs/serializers/attachment_serializer.py
+++ b/onadata/libs/serializers/attachment_serializer.py
@@ -10,7 +10,7 @@ def dict_key_for_value(_dict, value):
     """
     This function is used to get key by value in a dictionary
     """
-    return _dict.keys()[_dict.values().index(value)]
+    return list(_dict.keys())[list(_dict.values()).index(value)]
 
 
 def get_path(data, question_name, path_list=[]):


### PR DESCRIPTION
## Description

Fixed the media list endpoint (`/api/v1/media`) that was returning `500` due to `Python2.7`-`Python3` compatibility issues.

## Related issues

closes #773 