### PR TITLE
Add support to multi architecture docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs10
+FROM python:3.8
 
 # Declare environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -21,13 +21,6 @@ ENV VIRTUAL_ENV=/opt/venv \
     CELERY_PID_DIR=/var/run/celery \
     INIT_PATH=/srv/init
 
-# Install Dockerize
-# TODO: Remove this after merging kobotoolbox/kobo-docker#322
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz -P /tmp \
-    && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
 # Create needed directories
 RUN mkdir -p ${NGINX_STATIC_DIR} && \
     mkdir -p ${KOBOCAT_SRC_DIR} && \
@@ -42,9 +35,6 @@ RUN mkdir -p ${NGINX_STATIC_DIR} && \
     mkdir -p ${KOBOCAT_SRC_DIR}/emails && \
     mkdir -p ${INIT_PATH}
 
-# Install `apt` packages.
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-
 RUN apt-get -qq update && \
     apt-get -qq -y install \
         cron \
@@ -57,7 +47,6 @@ RUN apt-get -qq update && \
         locales \
         openjdk-11-jre \
         postgresql-client \
-        python3-virtualenv \
         rsync \
         runit-init \
         vim \
@@ -76,7 +65,7 @@ RUN adduser --disabled-password --gecos '' "$UWSGI_USER"
 COPY . "${KOBOCAT_SRC_DIR}"
 
 # Install `pip` packages
-RUN virtualenv "$VIRTUAL_ENV"
+RUN python3 -m venv "$VIRTUAL_ENV"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install  --quiet --upgrade pip && \
     pip install  --quiet pip-tools


### PR DESCRIPTION
## Description

The current base image of KPI `nikolaik/python-nodejs:python3.8-nodejs10` does not seem to support other plaforms than `x86_64/amd64`. Using Official Python image makes it possible. 
Morever, KoBoCAT does not need nodejs to be installed.

## Additional info 

For example, when we try to build the current image on ARM, docker raises this warning:

```
The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```