### PR TITLE
Reduce docker image size with multi stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ RUN adduser --disabled-password --gecos '' "$UWSGI_USER"
 
 # Copy virtualenv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY ./dependencies/pip/prod.txt "${TMP_DIR}/pip_dependencies.txt"
 COPY --from=build-python "$VIRTUAL_ENV" "$VIRTUAL_ENV"
 
 # Using `/etc/profile.d/` as a repository for non-hard-coded environment variable overrides.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ docker exec -it {{kobocat container}} /bin/bash
 Run pip install the development dependencies
 
 ``` sh
-$ pip install -r requirements/dev.pip
+$ pip install -r dependencies/pip/dev.txt
 ```
 
 Run pytest to run all automated tests


### PR DESCRIPTION
Taking a first stab at decreasing the docker image size. The benefits of that would be increasing speed for docker pulls (especially for those with slower connections). This would decrease the time it takes to scale up since things like k8s need to pull images on new nodes.

```
kobocat                                    dev.kobofe1639530239   14d155c6188d   10 minutes ago   1.86GB
kobotoolbox/kobocat                        2.021.47               0c477049279b   3 days ago       2.38GB
```

## Changes

- Use vim.tiny instead of vim (2206 kB vs 36.9 MB)
- Use python:3.8 to install python packages on built stage. Then copy virtual environment into python:3.8-slim. This removes a lot of -dev packages that aren't needed at runtime. It does not break instructions for installing dev dependencies. That did require adding git to the slim package.
- Minor update on README regarding how to pip install dev dependencies

## What I would like to change but did not

- Figure out why chown takes a huge amount of disk space and remove it
![image](https://user-images.githubusercontent.com/739307/146107022-0b8228ad-6a0f-410e-8cfa-287afb4d71ff.png)
- Consider replacing current uwsgi user with rootless docker image (this would mean we can't install dev packages at runtime). This is a security best practice.
```
RUN useradd -u 5000 app && chown -R app:app /code
USER app:app
```
- See if we can remove multiple python packages
```
aptitude why python3.9
i   gdal-bin      Depends python3-numpy (>= 1:1.16.0~rc1)
i A python3-numpy Depends python3 (>= 3.9~)              
i A python3       Depends python3.9 (>= 3.9.2-0~) 
```
I suppose we could pin the python version to specific Debian releases though it doesn't seem ideal typing the project's python version to Debian.

# Further reading

- Multi-stage builds https://docs.docker.com/develop/develop-images/multistage-build/
- SO talking about non-root Docker https://stackoverflow.com/questions/68155641/should-i-run-things-inside-a-docker-container-as-non-root-for-safety