### PR TITLE
Run `pip-sync` before `manage.py`

### DIFF
--- a/docker/init.bash
+++ b/docker/init.bash
@@ -27,7 +27,7 @@ else
     if ! diff -q "${KOBOCAT_SRC_DIR}/dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt"
     then
         echo "Syncing development pip dependencies..."
-        gosu "${UWSGI_USER}" pip-sync dependencies/pip/dev.txt 1>/dev/null
+        pip-sync dependencies/pip/dev.txt 1>/dev/null
         cp "dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt"
     fi
 fi

--- a/docker/init.bash
+++ b/docker/init.bash
@@ -13,6 +13,25 @@ if [[ -z $DATABASE_URL ]]; then
     exit 1
 fi
 
+# Handle Python dependencies BEFORE attempting any `manage.py` commands
+KOBOCAT_WEB_SERVER="${KOBOCAT_WEB_SERVER:-uWSGI}"
+if [[ "${KOBOCAT_WEB_SERVER,,}" == "uwsgi" ]]; then
+    # `diff` returns exit code 1 if it finds a difference between the files
+    DIFF=$(diff "${KOBOCAT_SRC_DIR}/dependencies/pip/prod.txt" "${TMP_DIR}/pip_dependencies.txt" || true)
+    if [[ -n "$DIFF" ]]; then
+        echo "Syncing production pip dependencies..."
+        pip-sync dependencies/pip/prod.txt 1>/dev/null
+        cp "dependencies/pip/prod.txt" "${TMP_DIR}/pip_dependencies.txt"
+    fi
+else
+    DIFF=$(diff "${KOBOCAT_SRC_DIR}/dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt" || true)
+    if [[ -n "$DIFF" ]]; then
+        echo "Syncing development pip dependencies..."
+        gosu "${UWSGI_USER}" pip-sync dependencies/pip/dev.txt 1>/dev/null
+        cp "dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt"
+    fi
+fi
+
 # Wait for databases to be up & running before going further
 /bin/bash "${INIT_PATH}/wait_for_mongo.bash"
 /bin/bash "${INIT_PATH}/wait_for_postgres.bash"

--- a/docker/init.bash
+++ b/docker/init.bash
@@ -17,15 +17,15 @@ fi
 KOBOCAT_WEB_SERVER="${KOBOCAT_WEB_SERVER:-uWSGI}"
 if [[ "${KOBOCAT_WEB_SERVER,,}" == "uwsgi" ]]; then
     # `diff` returns exit code 1 if it finds a difference between the files
-    DIFF=$(diff "${KOBOCAT_SRC_DIR}/dependencies/pip/prod.txt" "${TMP_DIR}/pip_dependencies.txt" || true)
-    if [[ -n "$DIFF" ]]; then
+    if ! diff -q "${KOBOCAT_SRC_DIR}/dependencies/pip/prod.txt" "${TMP_DIR}/pip_dependencies.txt"
+    then
         echo "Syncing production pip dependencies..."
         pip-sync dependencies/pip/prod.txt 1>/dev/null
         cp "dependencies/pip/prod.txt" "${TMP_DIR}/pip_dependencies.txt"
     fi
 else
-    DIFF=$(diff "${KOBOCAT_SRC_DIR}/dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt" || true)
-    if [[ -n "$DIFF" ]]; then
+    if ! diff -q "${KOBOCAT_SRC_DIR}/dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt"
+    then
         echo "Syncing development pip dependencies..."
         gosu "${UWSGI_USER}" pip-sync dependencies/pip/dev.txt 1>/dev/null
         cp "dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt"

--- a/docker/run_uwsgi.bash
+++ b/docker/run_uwsgi.bash
@@ -9,41 +9,11 @@ fi
 
 KOBOCAT_WEB_SERVER="${KOBOCAT_WEB_SERVER:-uWSGI}"
 
+cd "${KOBOCAT_SRC_DIR}"
 if [[ "${KOBOCAT_WEB_SERVER,,}" == "uwsgi" ]]; then
-    cd "${KOBOCAT_SRC_DIR}"
-    DIFF=$(diff "${KOBOCAT_SRC_DIR}/dependencies/pip/prod.txt" "${TMP_DIR}/pip_dependencies.txt")
-    if [[ -n "$DIFF" ]]; then
-        # Celery services need to be stopped to avoid raising errors
-        # during pip-sync
-        echo "Stopping Celery services..."
-        sv stop celery
-        sv stop celery_beat
-        echo "Syncing pip dependencies..."
-        pip-sync dependencies/pip/prod.txt 1>/dev/null
-        cp "dependencies/pip/prod.txt" "${TMP_DIR}/pip_dependencies.txt"
-        echo "Restarting Celery..."
-        sv start celery
-        sv start celery_beat
-    fi
     echo "Running \`KoBoCAT\` container with uWSGI application server."
     UWSGI_COMMAND="$(command -v uwsgi) --ini ${KOBOCAT_SRC_DIR}/docker/kobocat.ini"
 else
-    cd "${KOBOCAT_SRC_DIR}"
-    DIFF=$(diff "${KOBOCAT_SRC_DIR}/dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt")
-    if [[ -n "$DIFF" ]]; then
-        # Celery services need to be stopped to avoid raising errors during
-        # pip-sync
-        echo "Stopping Celery services..."
-        sv stop celery
-        sv stop celery_beat
-        echo "Syncing pip dependencies..."
-        gosu "${UWSGI_USER}" pip-sync dependencies/pip/dev.txt 1>/dev/null
-        cp "dependencies/pip/dev.txt" "${TMP_DIR}/pip_dependencies.txt"
-        echo "Restarting Celery..."
-        sv start celery
-        sv start celery_beat
-    fi
-
     echo "Running KoBoCAT container with \`runserver_plus\` debugging application server."
     UWSGI_COMMAND="gosu $UWSGI_USER python manage.py runserver_plus 0:8001"
 fi


### PR DESCRIPTION
## Description

Install Python dependencies before trying to run any Python scripts, fixing errors like `ModuleNotFoundError: No module named 'django_digest'` that previously required a full rebuild to resolve. Mirrors kobotoolbox/kpi#3607.