### PR TITLE
Block Enketo editing when anonymous submissions allowed

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -300,7 +300,9 @@ class TestDataViewSet(TestBase):
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             self.assertTrue(
                 response.data[0].startswith(
-                    'Cannot edit submissions while "Require authentication'
+                    'Cannot edit submissions while "Require authentication '
+                    'to see forms and submit data" is disabled for your '
+                    'account'
                 )
             )
 

--- a/onadata/apps/api/viewsets/xform_submission_api.py
+++ b/onadata/apps/api/viewsets/xform_submission_api.py
@@ -189,12 +189,12 @@ Here is some example JSON, it would replace `[the JSON]` above:
 
         is_json_request = is_json(request)
 
+        create_instance_func = (
+            create_instance_from_json
+            if is_json_request
+            else create_instance_from_xml
+        )
         try:
-            create_instance_func = (
-                create_instance_from_json
-                if is_json_request
-                else create_instance_from_xml
-            )
             error, instance = create_instance_func(username, request)
         except UnauthenticatedEditAttempt:
             # It's important to respond with a 401 instead of a 403 so that

--- a/onadata/apps/logger/tests/test_form_submission.py
+++ b/onadata/apps/logger/tests/test_form_submission.py
@@ -483,6 +483,18 @@ class TestFormSubmission(TestBase):
         )
 
     def test_authorized_user_can_edit_submissions_without_require_auth(self):
+        """
+        This is nice but unfortunately does not reflect how Enketo acts when
+        editing submissions. Enketo *always* sends an unauthenticated HEAD
+        request, even if the editing user has already provided credentials. If
+        the HEAD request does not receive a 401 response, Enketo will submit
+        anonymously.
+        There's no way to determine whether Enketo's HEAD was sent with the
+        intent of editing or making a new submission, making it effectively
+        impossible to support authenticated editing and anonymous (new)
+        submissions at the same time.
+        """
+
         self.assertFalse(self.user.profile.require_auth)
 
         xml_submission_file_path = os.path.join(


### PR DESCRIPTION
It leads to an infinite authentication loop in Enketo. This change rejects such doomed Enketo editing requests with an explanatory message.

Future Enketo editing will be done through KPI; see kobotoolbox/kpi#3654.

More detail, courtesy of @noliveleger:

> You are right, EE does not seem to send DigestAuth headers on POST (even if you are logged in Enketo Express) if  the previous HEAD call does not return a `401` (which is the case when [`required_authentication` is unchecked](https://github.com/kobotoolbox/kobocat/blob/b9c6615cbed6c67748eb6608c2a321209b483369/onadata/apps/api/viewsets/xform_submission_api.py#L179-L180)).
> Therefore the back end always sees the user as `AnonymousUser` when the data is [`POST`ed](https://github.com/kobotoolbox/kobocat/blob/b9c6615cbed6c67748eb6608c2a321209b483369/onadata/libs/utils/logger_tools.py#L190-L191)
> 
> I may be wrong, but I don't think we can detect whether the previous `HEAD` call is for edit or not, since it calls the same endpoint for creation and (obviously) does not send  the XML file.
> 
> **EE code refs:**
> 
> - [HEAD to `/<username>/submission`](https://github.com/enketo/enketo-express/blob/418233abdbb197ea2610ee856a39f25d5a78c44c/app/controllers/submission-controller.js#L66)
> - [Return `null` if HEAD endpoint does not return a 401](https://github.com/enketo/enketo-express/blob/418233abdbb197ea2610ee856a39f25d5a78c44c/app/lib/communicator/communicator.js#L171-L184)
> - [POST to `/<username>/submission` (with headers previously retrieved or none)](https://github.com/enketo/enketo-express/blob/418233abdbb197ea2610ee856a39f25d5a78c44c/app/controllers/submission-controller.js#L73-L75)
