### PR TITLE
Use `UTC` timezone in Django settings

### DIFF
--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -59,7 +59,7 @@ DEFAULT_SESSION_EXPIRY_TIME = 21600  # 6 hours
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'America/New_York'
+TIME_ZONE = 'UTC'
 USE_TZ = True
 
 # Language code for this installation. All choices can be found here:


### PR DESCRIPTION
Everything piece of KoboToolbox app is in UTC. 

As per our discussion:
> Let the front end convert UTC to local times

