### PR TITLE
Remove `select_for_update()` locking from paired data timestamp update

### DIFF
--- a/onadata/apps/main/models/meta_data.py
+++ b/onadata/apps/main/models/meta_data.py
@@ -182,7 +182,12 @@ class MetaData(models.Model):
             # `PAIRED_DATA_EXPIRATION` period. However, this introduces a race
             # condition where it's possible that KPI *deletes* this file before
             # we attempt to update it. We avoid that by locking the row
-            MetaData.objects.filter(pk=self.pk).select_for_update().update(
+            ### TODO: this previously used `select_for_update()`, which locked
+            ### the object for the duration of the *entire* request due to
+            ### Django's `ATOMIC_REQUESTS`. The `update()` method is itself
+            ### atomic since it does not reference any value previously read
+            ### from the database. Is that enough?
+            MetaData.objects.filter(pk=self.pk).update(
                 date_modified=timezone.now()
             )
             return True


### PR DESCRIPTION
The `update()` itself is atomic, but it remains to be seen if the paired data synchronization logic will suffer without holding these locks for the duration of the entire kobocat request.

@noliveleger, this is already part of 2.022.08b, but I would like a proper review and possible update of the comments I wrote in the code. I don't really understand for how long a `MetaData` row needs to be locked to avoid the KPI-deletion race condition you describe in the comment explaining the original `select_for_update()`. We had a limited internal discussion about this at https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/paired.20data.20database.20locks/near/97138.

## Description

Fix a performance bottleneck in the "Connect Projects" / "dynamic data attachments" feature