### PR TITLE
Pin pip version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV VIRTUAL_ENV=/opt/venv \
 # Install `pip` packages
 RUN python3 -m venv "$VIRTUAL_ENV"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install  --quiet --upgrade pip && \
+RUN pip install  --quiet pip==22.0.4 && \
     pip install  --quiet pip-tools
 COPY ./dependencies/pip/prod.txt "${TMP_DIR}/pip_dependencies.txt"
 RUN pip-sync "${TMP_DIR}/pip_dependencies.txt" 1>/dev/null


### PR DESCRIPTION
Build failing due to https://github.com/jazzband/pip-tools/issues/1617, therefore pin to previous working version.