### PR TITLE
Add support for MongoDB connections over TLS/SSL

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Upgrade pip
-      run: python -m pip install --upgrade pip
+      run: python -m pip install pip==22.0.4
     - name: Update apt package lists
       run: sudo apt update
     - name: Install apt dependencies

--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -755,6 +755,7 @@ MONGO_CONNECTION = MongoClient(
     journal=True,
     tz_aware=True,
     tls=env.bool('MONGO_USE_TLS', False),
+    tlsCAFile=env.str('MONGO_TLS_CA_FILE', None),
 )
 
 MONGO_DB = MONGO_CONNECTION[MONGO_DATABASE['NAME']]

--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -751,7 +751,11 @@ else:
 # PyMongo 3 does acknowledged writes by default
 # https://emptysqua.re/blog/pymongos-new-default-safe-writes/
 MONGO_CONNECTION = MongoClient(
-    MONGO_CONNECTION_URL, j=True, tz_aware=True)
+    MONGO_CONNECTION_URL,
+    journal=True,
+    tz_aware=True,
+    tls=env.bool('MONGO_USE_TLS', False),
+)
 
 MONGO_DB = MONGO_CONNECTION[MONGO_DATABASE['NAME']]
 


### PR DESCRIPTION
## Description

Add the possibility to use a secure connection between KPI and MongoDB.

## Additional info

Environment variable `MONGO_USE_TLS` must be passed to the container and should be set to `True`. 
Usually, when a secure connection is enable with `pymongo` the CA certificate should be fetch from server. 

From PyMongo documentation: 
> In many cases connecting to MongoDB over TLS/SSL requires nothing more than passing tls=True as a keyword argument to [MongoClient](https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient)

Unfortunately, some services require to download certificates apart (e.g. AWS DocumentDB). `MONGO_TLS_CA_FILE` can be used to specify the path of certificate

## Related issues

Closes #818 
Related to kobotoolbox/kpi#3807 