### PR TITLE
Fix `ImportError` with Python 3.8

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.8', '3.10']
     services:
       postgres:
         image: postgis/postgis:9.5-2.5

--- a/dependencies/pip/dev.txt
+++ b/dependencies/pip/dev.txt
@@ -26,6 +26,8 @@ azure-storage-blob==12.11.0
     # via django-storages
 backcall==0.2.0
     # via ipython
+backports-zoneinfo==0.2.1; python_version < '3.9'
+    # via -r dependencies/pip/requirements.in
 billiard==3.6.4.0
     # via celery
 boto3==1.22.0

--- a/dependencies/pip/prod.txt
+++ b/dependencies/pip/prod.txt
@@ -20,6 +20,8 @@ azure-core==1.23.1
     # via azure-storage-blob
 azure-storage-blob==12.11.0
     # via django-storages
+backports-zoneinfo==0.2.1; python_version < '3.9'
+    # via -r dependencies/pip/requirements.in
 billiard==3.6.4.0
     # via celery
 boto3==1.22.0

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -81,3 +81,6 @@ sentry-sdk
 
 # mimetype detection
 Werkzeug<=2.0.3
+
+# Python 3.8 support
+backports.zoneinfo; python_version < '3.9'

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -20,6 +20,8 @@ azure-core==1.23.1
     # via azure-storage-blob
 azure-storage-blob==12.11.0
     # via django-storages
+backports-zoneinfo==0.2.1; python_version < '3.9'
+    # via -r dependencies/pip/requirements.in
 billiard==3.6.4.0
     # via celery
 boto3==1.22.0

--- a/onadata/apps/api/viewsets/xform_list_api.py
+++ b/onadata/apps/api/viewsets/xform_list_api.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 from datetime import datetime
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.http import Http404

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 from datetime import date
 from hashlib import sha256
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import reversion
 from django.contrib.auth.models import User

--- a/onadata/apps/viewer/tasks.py
+++ b/onadata/apps/viewer/tasks.py
@@ -3,7 +3,10 @@ import logging
 import re
 import sys
 from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from celery import shared_task
 from django.conf import settings

--- a/onadata/libs/mixins/openrosa_headers_mixin.py
+++ b/onadata/libs/mixins/openrosa_headers_mixin.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 from datetime import datetime
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from django.conf import settings
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -5,7 +5,10 @@ import sys
 import traceback
 from datetime import date, datetime
 from xml.parsers.expat import ExpatError
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from dict2xml import dict2xml
 from django.conf import settings


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Bring back Python 3.8 support for users who do not use kobo-docker/docker containers.

## Additional info

Starting from Python 3.9, `pytz` has been replaced by `zoneinfo`. Unfortunately, it is not supported by Python 3.8 and below.
With `backports.zoneinfo`, it is possible to run with Python 3.8 again.

```python
try:
    from zoneinfo import ZoneInfo
except ImportError:
    from backports.zoneinfo import ZoneInfo
```

## Related issues
kobotoolbox/kpi#3809
