### PR TITLE
Sentry - configure traces rate

### DIFF
--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -777,7 +777,7 @@ if sentry_dsn:
     # All of this is already happening by default!
     sentry_logging = LoggingIntegration(
         level=logging.INFO,  # Capture info and above as breadcrumbs
-        event_level=logging.ERROR  # Send warnings as events
+        event_level=logging.ERROR  # Send errors as events
     )
     sentry_sdk.init(
         dsn=sentry_dsn,

--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -767,7 +767,7 @@ MONGO_DB_MAX_TIME_MS = CELERY_TASK_TIME_LIMIT * 1000
 ################################
 # Sentry settings              #
 ################################
-sentry_dsn = env.str("SENTRY_DSN", env.str("RAVEN_DSN", None))
+sentry_dsn = env.str('SENTRY_DSN', env.str('RAVEN_DSN', None))
 if sentry_dsn:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
@@ -786,6 +786,6 @@ if sentry_dsn:
             CeleryIntegration(),
             sentry_logging
         ],
-        traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", 0.05),
+        traces_sample_rate=env.float('SENTRY_TRACES_SAMPLE_RATE', 0.05),
         send_default_pii=True
     )

--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -767,8 +767,8 @@ MONGO_DB_MAX_TIME_MS = CELERY_TASK_TIME_LIMIT * 1000
 ################################
 # Sentry settings              #
 ################################
-
-if env.str('RAVEN_DSN', None):
+sentry_dsn = env.str("SENTRY_DSN", env.str("RAVEN_DSN", None))
+if sentry_dsn:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.celery import CeleryIntegration
@@ -777,14 +777,15 @@ if env.str('RAVEN_DSN', None):
     # All of this is already happening by default!
     sentry_logging = LoggingIntegration(
         level=logging.INFO,  # Capture info and above as breadcrumbs
-        event_level=logging.ERROR  # Send errors as events
+        event_level=logging.ERROR  # Send warnings as events
     )
     sentry_sdk.init(
-        dsn=env.str('RAVEN_DSN'),
+        dsn=sentry_dsn,
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),
             sentry_logging
         ],
+        traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", 0.05),
         send_default_pii=True
     )


### PR DESCRIPTION
## Description

Allow editing Sentry traces rate with env var SENTRY_TRACES_SAMPLE_RATE which defaults to 0.05 (%)

## Implementation

I'm also refactoring it just slightly and preferring the env var SENTRY_DSN with backwards compatibility for RAVEN_DSN. Raven no longer exists. It should match kpi more closely now.

## Related issues

Related to https://github.com/kobotoolbox/kpi/pull/3810