### PR TITLE
Allow to pass extra parameters to MongoDB driver

### DIFF
--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -702,33 +702,43 @@ ENKETO_PROTOCOL = os.environ.get('ENKETO_PROTOCOL', 'https')
 ################################
 # MongoDB settings             #
 ################################
+if not (MONGO_DB_URL := env.str('MONGO_DB_URL', False)):
+    # ToDo Remove all this block by the end of 2022.
+    #   Update kobo-install accordingly
+    logging.warning(
+        '`MONGO_DB_URL` is not found. '
+        '`KOBOCAT_MONGO_HOST`, `KOBOCAT_MONGO_PORT`, `KOBOCAT_MONGO_NAME`, '
+        '`KOBOCAT_MONGO_USER`, `KOBOCAT_MONGO_PASS` '
+        'are deprecated and will not be supported anymore soon.'
+    )
 
-MONGO_DATABASE = {
-    'HOST': os.environ.get('KOBOCAT_MONGO_HOST', 'mongo'),
-    'PORT': int(os.environ.get('KOBOCAT_MONGO_PORT', 27017)),
-    'NAME': os.environ.get('KOBOCAT_MONGO_NAME', 'formhub'),
-    'USER': os.environ.get('KOBOCAT_MONGO_USER', ''),
-    'PASSWORD': os.environ.get('KOBOCAT_MONGO_PASS', '')
-}
+    MONGO_DATABASE = {
+        'HOST': os.environ.get('KOBOCAT_MONGO_HOST', 'mongo'),
+        'PORT': int(os.environ.get('KOBOCAT_MONGO_PORT', 27017)),
+        'NAME': os.environ.get('KOBOCAT_MONGO_NAME', 'formhub'),
+        'USER': os.environ.get('KOBOCAT_MONGO_USER', ''),
+        'PASSWORD': os.environ.get('KOBOCAT_MONGO_PASS', '')
+    }
 
-if MONGO_DATABASE.get('USER') and MONGO_DATABASE.get('PASSWORD'):
-    MONGO_CONNECTION_URL = "mongodb://{user}:{password}@{host}:{port}/{db_name}".\
-        format(
-            user=MONGO_DATABASE['USER'],
-            password=quote_plus(MONGO_DATABASE['PASSWORD']),
-            host=MONGO_DATABASE['HOST'],
-            port=MONGO_DATABASE['PORT'],
-            db_name=MONGO_DATABASE['NAME']
-        )
+    if MONGO_DATABASE.get('USER') and MONGO_DATABASE.get('PASSWORD'):
+        MONGO_DB_URL = "mongodb://{user}:{password}@{host}:{port}/{db_name}".\
+            format(
+                user=MONGO_DATABASE['USER'],
+                password=quote_plus(MONGO_DATABASE['PASSWORD']),
+                host=MONGO_DATABASE['HOST'],
+                port=MONGO_DATABASE['PORT'],
+                db_name=MONGO_DATABASE['NAME']
+            )
+    else:
+        MONGO_DB_URL = "mongodb://%(HOST)s:%(PORT)s/%(NAME)s" % MONGO_DATABASE
+    mongo_db_name = MONGO_DATABASE['NAME']
 else:
-    MONGO_CONNECTION_URL = "mongodb://%(HOST)s:%(PORT)s/%(NAME)s" % MONGO_DATABASE
+    # Get collection name from the connection string, fallback on 'formhub' if
+    # it is empty or None
+    mongo_db_name = env.db_url('MONGO_DB_URL').get('NAME') or 'formhub'
 
-# PyMongo 3 does acknowledged writes by default
-# https://emptysqua.re/blog/pymongos-new-default-safe-writes/
-MONGO_CONNECTION = MongoClient(
-    MONGO_CONNECTION_URL, j=True, tz_aware=True)
-
-MONGO_DB = MONGO_CONNECTION[MONGO_DATABASE['NAME']]
+mongo_client = MongoClient(MONGO_DB_URL, journal=True, tz_aware=True)
+MONGO_DB = mongo_client[mongo_db_name]
 
 # Timeout for Mongo, must be, at least, as long as Celery timeout.
 MONGO_DB_MAX_TIME_MS = CELERY_TASK_TIME_LIMIT * 1000


### PR DESCRIPTION
## Description

Implement a new environment variable `MONGO_DB_URL` which gives more flexibility to pass extra parameters (e.g. `tls=True`).

## Additional info 

Refer to [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/connection-string/) for connection string format expected in `MONGO_DB_URL` 

These environment variables are deprecated and will be removed in a future release:

- `KOBOCAT_MONGO_HOST`
- `KOBOCAT_MONGO_PORT` 
- `KOBOCAT_MONGO_NAME`
- `KOBOCAT_MONGO_USER`
- `KOBOCAT_MONGO_PASS`

## Related issues

Supersedes #819
Related to kobotoolbox/kpi#3817
