### PR TITLE
Make HEAD requests to OpenRosa endpoints return empty responses

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -106,6 +106,12 @@ class TestAbstractViewSet(MakeSubmissionMixin, TestCase):
             'metadata': {},
         }
 
+    def validate_openrosa_head_response(self, response):
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(response.data)  # should be empty
+        self.assertIn('X-OpenRosa-Accept-Content-Length', response)
+        self.assertIn('X-OpenRosa-Version', response)
+
     def _add_permissions_to_user(self, user, save=True):
         """
         Gives `user` unrestricted model-level access to everything listed in

--- a/onadata/apps/api/tests/viewsets/test_xform_list_api.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_api.py
@@ -22,6 +22,15 @@ class TestXFormListApi(TestAbstractViewSet):
         })
         self.publish_xls_form()
 
+    def test_head_xform_list(self):
+        request = self.factory.head('/')
+        response = self.view(request)
+        self.assertEqual(response.status_code, 401)
+        auth = DigestAuth('bob', 'bobbob')
+        request.META.update(auth(request.META, response))
+        response = self.view(request)
+        self.validate_openrosa_head_response(response)
+
     def test_get_xform_list(self):
         request = self.factory.get('/')
         response = self.view(request)
@@ -264,6 +273,19 @@ class TestXFormListApi(TestAbstractViewSet):
 
         self._add_form_metadata(xform, data_type, data_value, path)
 
+    def test_head_xform_manifest(self):
+        self._load_metadata(self.xform)
+        self.view = XFormListApi.as_view({
+            "get": "manifest"
+        })
+        request = self.factory.head('/')
+        response = self.view(request, pk=self.xform.pk)
+        self.assertEqual(response.status_code, 401)
+        auth = DigestAuth('bob', 'bobbob')
+        request.META.update(auth(request.META, response))
+        response = self.view(request, pk=self.xform.pk)
+        self.validate_openrosa_head_response(response)
+
     def test_retrieve_xform_manifest(self):
         self._load_metadata(self.xform)
         self.view = XFormListApi.as_view({
@@ -327,6 +349,21 @@ class TestXFormListApi(TestAbstractViewSet):
                              username=self.user.username)
         self.assertEqual(response.status_code, 401)
 
+    def test_head_xform_media(self):
+        self._load_metadata(self.xform)
+        self.view = XFormListApi.as_view({
+            "get": "media"
+        })
+        request = self.factory.head('/')
+        response = self.view(request, pk=self.xform.pk,
+                             metadata=self.metadata.pk, format='png')
+        self.assertEqual(response.status_code, 401)
+        auth = DigestAuth('bob', 'bobbob')
+        request.META.update(auth(request.META, response))
+        response = self.view(request, pk=self.xform.pk,
+                             metadata=self.metadata.pk, format='png')
+        self.validate_openrosa_head_response(response)
+
     def test_retrieve_xform_media(self):
         self._load_metadata(self.xform)
         self.view = XFormListApi.as_view({
@@ -335,6 +372,7 @@ class TestXFormListApi(TestAbstractViewSet):
         request = self.factory.head('/')
         response = self.view(request, pk=self.xform.pk,
                              metadata=self.metadata.pk, format='png')
+        self.assertEqual(response.status_code, 401)
         auth = DigestAuth('bob', 'bobbob')
         request = self.factory.get('/')
         request.META.update(auth(request.META, response))

--- a/onadata/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -25,6 +25,15 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
         })
         self.publish_xls_form()
 
+    def test_head_response(self):
+        request = self.factory.head('/submission')
+        response = self.view(request)
+        self.assertEqual(response.status_code, 401)
+        auth = DigestAuth('bob', 'bobbob')
+        request.META.update(auth(request.META, response))
+        response = self.view(request)
+        self.validate_openrosa_head_response(response)
+
     def test_post_submission_anonymous(self):
         s = self.surveys[0]
         media_file = "1335783522563.jpg"

--- a/onadata/apps/viewer/tests/test_export_builder.py
+++ b/onadata/apps/viewer/tests/test_export_builder.py
@@ -12,7 +12,6 @@ from django.core.files.temp import NamedTemporaryFile
 from django.utils.six import string_types
 from openpyxl import load_workbook
 from pyxform.builder import create_survey_from_xls
-from savReaderWriter import SavReader
 
 from onadata.apps.api.mongo_helper import MongoHelper
 from onadata.apps.main.tests.test_base import TestBase


### PR DESCRIPTION
## Description

Hopefully fixes the `Parse Error: Expected HTTP/` seen in Enketo when NGINX is not used, e.g. in local development environments. See also kobotoolbox/kpi#3828