### PR TITLE
django-digest redis cache nonce storage backend

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -52,4 +52,5 @@ jobs:
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
         TEST_DATABASE_URL: postgis://kobo:kobo@localhost:5432/kobocat_test
         REDIS_SESSION_URL: redis://localhost:6380/2
+        CACHE_URL: redis://localhost:6380/3
         USE_POSTGRESQL: True

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,8 @@ test:
   variables:
     DJANGO_SECRET_KEY: abcdef
     TEST_DATABASE_URL: postgis://kobo:kobo@postgres:5432/kobocat_test
-    REDIS_SESSION_URL: redis://localhost:6380/2
+    REDIS_SESSION_URL: redis://redis_cache:6379/2
+    CACHE_URL: redis://redis_cache:6379/3
     USE_POSTGRESQL: "True"
     POSTGRES_USER: kobo
     POSTGRES_PASSWORD: kobo

--- a/dependencies/pip/dev.txt
+++ b/dependencies/pip/dev.txt
@@ -90,6 +90,7 @@ django==2.2.28
     #   django-filter
     #   django-guardian
     #   django-oauth-toolkit
+    #   django-redis
     #   django-render-block
     #   django-reversion
     #   django-storages
@@ -119,6 +120,8 @@ django-guardian==2.4.0
 django-oauth-toolkit==2.0.0
     # via -r dependencies/pip/requirements.in
 django-pure-pagination==0.3.0
+    # via -r dependencies/pip/requirements.in
+django-redis==5.2.0
     # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.2
     # via -r dependencies/pip/requirements.in
@@ -281,6 +284,7 @@ redis==4.2.2
     # via
     #   -r dependencies/pip/requirements.in
     #   celery
+    #   django-redis
     #   django-redis-sessions
 requests==2.27.1
     # via

--- a/dependencies/pip/prod.txt
+++ b/dependencies/pip/prod.txt
@@ -80,6 +80,7 @@ django==2.2.28
     #   django-filter
     #   django-guardian
     #   django-oauth-toolkit
+    #   django-redis
     #   django-render-block
     #   django-reversion
     #   django-storages
@@ -109,6 +110,8 @@ django-guardian==2.4.0
 django-oauth-toolkit==2.0.0
     # via -r dependencies/pip/requirements.in
 django-pure-pagination==0.3.0
+    # via -r dependencies/pip/requirements.in
+django-redis==5.2.0
     # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.2
     # via -r dependencies/pip/requirements.in
@@ -221,6 +224,7 @@ redis==4.2.2
     # via
     #   -r dependencies/pip/requirements.in
     #   celery
+    #   django-redis
     #   django-redis-sessions
 requests==2.27.1
     # via

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -16,6 +16,7 @@ https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip#
 Django>=2.2,<2.3
 django-csp
 django-environ
+django-redis
 django-storages[azure,boto3]
 django-templated-email
 dpath

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -80,6 +80,7 @@ django==2.2.28
     #   django-filter
     #   django-guardian
     #   django-oauth-toolkit
+    #   django-redis
     #   django-render-block
     #   django-reversion
     #   django-storages
@@ -109,6 +110,8 @@ django-guardian==2.4.0
 django-oauth-toolkit==2.0.0
     # via -r dependencies/pip/requirements.in
 django-pure-pagination==0.3.0
+    # via -r dependencies/pip/requirements.in
+django-redis==5.2.0
     # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.2
     # via -r dependencies/pip/requirements.in
@@ -221,6 +224,7 @@ redis==4.2.2
     # via
     #   -r dependencies/pip/requirements.in
     #   celery
+    #   django-redis
     #   django-redis-sessions
 requests==2.27.1
     # via

--- a/onadata/apps/django_digest_backends/cache.py
+++ b/onadata/apps/django_digest_backends/cache.py
@@ -19,7 +19,7 @@ class RedisCacheNonceStorage():
         """
         Check and update nonce record. If no record exists or has an invalid count,
         return False. Create a lock to prevent a concurrent replay attack where
-        two requests are send immediately and either may finish first.
+        two requests are sent immediately and either may finish first.
         """
         cache = self._get_cache()
         cache_key = self._generate_cache_key(user, nonce)

--- a/onadata/apps/django_digest_backends/cache.py
+++ b/onadata/apps/django_digest_backends/cache.py
@@ -1,16 +1,19 @@
 from django.core.cache import caches
 from django_digest.utils import get_setting
+from redis.exceptions import LockError
 
-
-DIGEST_NONCE_CACHE_NAME = get_setting('DIGEST_NONCE_CACHE_NAME', 'default')
-NONCE_TIMEOUT = get_setting('DIGEST_NONCE_TIMEOUT_IN_SECONDS', 5 * 60)
 NONCE_NO_COUNT = ''  # Needs to be something other than None to determine not set vs set to null
 
 
 class RedisCacheNonceStorage():
+    _blocking_timeout = 30
+
     def _get_cache(self):
         # Dynamic fetching of cache is necessary to work with override_settings
-        return caches[DIGEST_NONCE_CACHE_NAME]
+        return caches[get_setting('DIGEST_NONCE_CACHE_NAME', 'default')]
+
+    def _get_timeout(self):
+        return get_setting('DIGEST_NONCE_TIMEOUT_IN_SECONDS', 5 * 60)
 
     def _generate_cache_key(self, user, nonce):
         return f'user_nonce_{user}_{nonce}'
@@ -28,19 +31,23 @@ class RedisCacheNonceStorage():
             existing = cache.get(cache_key)
             if existing is None:
                 return False
-            cache.set(cache_key, NONCE_NO_COUNT, NONCE_TIMEOUT)
+            cache.set(cache_key, NONCE_NO_COUNT, self._get_timeout())
         else:
-            with cache.lock(
-                f'user_nonce_lock_{user}_{nonce}',
-                timeout=NONCE_TIMEOUT,
-                blocking_timeout=30
-            ):
-                existing = cache.get(cache_key)
-                if existing is None:
-                    return False
-                if nonce_count <= existing:
-                    return False
-                cache.set(cache_key, nonce_count, NONCE_TIMEOUT)
+            try:
+                with cache.lock(
+                    f'user_nonce_lock_{user}_{nonce}',
+                    timeout=self._get_timeout(),
+                    blocking_timeout=self._blocking_timeout
+                ):
+                    existing = cache.get(cache_key)
+                    if existing is None:
+                        return False
+                    if nonce_count <= existing:
+                        return False
+                    cache.set(cache_key, nonce_count, self._get_timeout())
+            except LockError:
+                cache.delete(cache_key)
+                return False
         return True
 
     def store_nonce(self, user, nonce, nonce_count):
@@ -51,4 +58,4 @@ class RedisCacheNonceStorage():
             nonce_count = NONCE_NO_COUNT
         cache = self._get_cache()
         cache_key = self._generate_cache_key(user, nonce)
-        return cache.set(cache_key, nonce_count, NONCE_TIMEOUT)
+        return cache.set(cache_key, nonce_count, self._get_timeout())

--- a/onadata/apps/django_digest_backends/cache.py
+++ b/onadata/apps/django_digest_backends/cache.py
@@ -1,0 +1,54 @@
+from django.core.cache import caches
+from django_digest.utils import get_setting
+
+
+DIGEST_NONCE_CACHE_NAME = get_setting('DIGEST_NONCE_CACHE_NAME', 'default')
+NONCE_TIMEOUT = get_setting('DIGEST_NONCE_TIMEOUT_IN_SECONDS', 5 * 60)
+NONCE_NO_COUNT = ''  # Needs to be something other than None to determine not set vs set to null
+
+
+class RedisCacheNonceStorage():
+    def _get_cache(self):
+        # Dynamic fetching of cache is necessary to work with override_settings
+        return caches[DIGEST_NONCE_CACHE_NAME]
+
+    def _generate_cache_key(self, user, nonce):
+        return f'user_nonce_{user}_{nonce}'
+
+    def update_existing_nonce(self, user, nonce, nonce_count):
+        """
+        Check and update nonce record. If no record exists or has an invalid count,
+        return False. Create a lock to prevent a concurrent replay attack where
+        two requests are send immediately and either may finish first.
+        """
+        cache = self._get_cache()
+        cache_key = self._generate_cache_key(user, nonce)
+
+        if nonce_count == None:  # No need to lock
+            existing = cache.get(cache_key)
+            if existing is None:
+                return False
+            cache.set(cache_key, NONCE_NO_COUNT, NONCE_TIMEOUT)
+        else:
+            with cache.lock(
+                f'user_nonce_lock_{user}_{nonce}',
+                timeout=NONCE_TIMEOUT,
+                blocking_timeout=30
+            ):
+                existing = cache.get(cache_key)
+                if existing is None:
+                    return False
+                if nonce_count <= existing:
+                    return False
+                cache.set(cache_key, nonce_count, NONCE_TIMEOUT)
+        return True
+
+    def store_nonce(self, user, nonce, nonce_count):
+        # Nonce is required
+        if nonce is None or len(nonce) <= 1:
+            return False
+        if nonce_count is None:
+            nonce_count = NONCE_NO_COUNT
+        cache = self._get_cache()
+        cache_key = self._generate_cache_key(user, nonce)
+        return cache.set(cache_key, nonce_count, NONCE_TIMEOUT)

--- a/onadata/apps/django_digest_backends/tests.py
+++ b/onadata/apps/django_digest_backends/tests.py
@@ -1,0 +1,41 @@
+from django.core.cache import caches
+from django.test import TestCase
+from .cache import RedisCacheNonceStorage
+
+
+class TestCacheNonceStorage(TestCase):
+    def setUp(self):
+        self.test_user = 'user'
+        self.cache = caches['default']
+        self.storage = RedisCacheNonceStorage()
+
+    def test_store_and_update(self):
+        self.storage.store_nonce(self.test_user, 'abc', '')
+        self.assertEqual(self.cache.get(f'user_nonce_{self.test_user}_abc'), '')
+
+        # Should return true if the user + nonce already exists
+        self.assertTrue(self.storage.update_existing_nonce(self.test_user, 'abc', None))
+
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'ab', None))
+        self.assertFalse(self.storage.update_existing_nonce('someone', 'abc', None))
+
+        self.cache.clear()
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'abc', None))
+        # update should never create
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'abc', None))
+
+    def test_update_count(self):
+        self.storage.store_nonce(self.test_user, 'abc', 2)
+
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'abc', 2))
+        self.assertTrue(self.storage.update_existing_nonce(self.test_user, 'abc', 3))
+    
+    def xtest_nonce_lock(self):
+        """
+        Prove the lock halts execution, intended to be manually run
+        """
+        nonce = 'abc'
+        self.storage.store_nonce(self.test_user, nonce, 1)
+        with self.cache.lock(f'user_nonce_lock_{self.test_user}_{nonce}'):
+            self.storage.update_existing_nonce(self.test_user, nonce, 2)
+        self.assertTrue()

--- a/onadata/apps/django_digest_backends/tests.py
+++ b/onadata/apps/django_digest_backends/tests.py
@@ -5,36 +5,36 @@ from .cache import RedisCacheNonceStorage
 
 class TestCacheNonceStorage(TestCase):
     def setUp(self):
-        self.test_user = 'user'
+        self.test_user = 'bob'
         self.cache = caches['default']
         self.storage = RedisCacheNonceStorage()
 
     def test_store_and_update(self):
-        self.storage.store_nonce(self.test_user, 'abc', '')
-        self.assertEqual(self.cache.get(f'user_nonce_{self.test_user}_abc'), '')
+        self.storage.store_nonce(self.test_user, 'testnonce', '')
+        self.assertEqual(self.cache.get(f'user_nonce_{self.test_user}_testnonce'), '')
 
         # Should return true if the user + nonce already exists
-        self.assertTrue(self.storage.update_existing_nonce(self.test_user, 'abc', None))
+        self.assertTrue(self.storage.update_existing_nonce(self.test_user, 'testnonce', None))
 
-        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'ab', None))
-        self.assertFalse(self.storage.update_existing_nonce('someone', 'abc', None))
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'bogusnonce', None))
+        self.assertFalse(self.storage.update_existing_nonce('alice', 'testnonce', None))
 
         self.cache.clear()
-        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'abc', None))
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'testnonce', None))
         # update should never create
-        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'abc', None))
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'testnonce', None))
 
     def test_update_count(self):
-        self.storage.store_nonce(self.test_user, 'abc', 2)
+        self.storage.store_nonce(self.test_user, 'testnonce', 2)
 
-        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'abc', 2))
-        self.assertTrue(self.storage.update_existing_nonce(self.test_user, 'abc', 3))
+        self.assertFalse(self.storage.update_existing_nonce(self.test_user, 'testnonce', 2))
+        self.assertTrue(self.storage.update_existing_nonce(self.test_user, 'testnonce', 3))
     
     def xtest_nonce_lock(self):
         """
         Prove the lock halts execution, intended to be manually run
         """
-        nonce = 'abc'
+        nonce = 'testnonce'
         self.storage.store_nonce(self.test_user, nonce, 1)
         with self.cache.lock(f'user_nonce_lock_{self.test_user}_{nonce}'):
             self.storage.update_existing_nonce(self.test_user, nonce, 2)

--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -396,6 +396,13 @@ SESSION_REDIS = {
     'socket_timeout': env.int('REDIS_SESSION_SOCKET_TIMEOUT', 1),
 }
 
+CACHES = {
+    # Set CACHE_URL to override. Only redis is supported.
+    'default': env.cache(default='redis://redis_cache:6380/3'),
+}
+
+DIGEST_NONCE_BACKEND = "onadata.apps.django_digest_backends.cache.RedisCacheNonceStorage"
+
 ###################################
 # Django Rest Framework settings  #
 ###################################

--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -401,7 +401,7 @@ CACHES = {
     'default': env.cache(default='redis://redis_cache:6380/3'),
 }
 
-DIGEST_NONCE_BACKEND = "onadata.apps.django_digest_backends.cache.RedisCacheNonceStorage"
+DIGEST_NONCE_BACKEND = 'onadata.apps.django_digest_backends.cache.RedisCacheNonceStorage'
 
 ###################################
 # Django Rest Framework settings  #


### PR DESCRIPTION
This change solves a deadlock issue from the django-digest database nonce storage backend. django-digest can potentially delete a lot of old nonces all at once, while storing a new one. If this happens while an update occurs, which happens when checking an existing nonce, it deadlocks.

This redis based backend fixes this by storing nonces in redis with a TTL. No additional nonce cleanup is necessary. It requires a blocking redis lock to prevent replay attacks. The lock has sane timeouts applied. Because nonces are small and transient, in memory storage is appropriate. Nonces can also be deleted at any time without apparent consequence (I'm still verifying this claim). It would be fine to store these in a ephemeral redis instance if desired.

Introduces new default cache backend that matches KPI implementation. Only django-redis is supported due to the need for redis locking.

**This PR requires a change to kobo-install to set the new CACHE_URL environment variable**

I believe this PR is finished, but I'd like to test it further before marking as ready.