### PR TITLE
Raise superuser_stats time limit to one hour

### DIFF
--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -36,7 +36,7 @@ def fix_root_node_names(**kwargs):
 # #### END ISSUE 242 FIX ######
 
 
-@shared_task
+@shared_task(soft_time_limit=3600, time_limit=3630)
 def generate_stats_zip(output_filename):
     # Limit to last month and this month
     now = datetime.datetime.now()


### PR DESCRIPTION
Default 30-minute limit was too short for large instances