### PR TITLE
Fix "Code challenge required" error when using OAuth2 applications

### DIFF
--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -485,7 +485,9 @@ OAUTH2_PROVIDER = {
     'SCOPES': {
         'read': 'Read scope',
         'write': 'Write scope',
-        'groups': 'Access to your groups'}
+        'groups': 'Access to your groups'
+    },
+    'PKCE_REQUIRED' : False,
 }
 
 # All registration should be done through KPI, so Django Registration should


### PR DESCRIPTION
## Description 

The recent upgrade of OAuth2 package enforces the requirement of `PKCE` by default.
This requirement is reverted for retro-compatibility.
