### PR TITLE
Remove AlterUniqueTogether for SubmissionCounter…

### DIFF
--- a/onadata/apps/logger/migrations/0024_add_xform_counters.py
+++ b/onadata/apps/logger/migrations/0024_add_xform_counters.py
@@ -13,10 +13,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterUniqueTogether(
-            name='submissioncounter',
-            unique_together={('user', 'timestamp')},
-        ),
         migrations.CreateModel(
             name='MonthlyXFormSubmissionCounter',
             fields=[


### PR DESCRIPTION
since that entire model is immediately deleted by the next migration. Fixes issues like:
```
django.db.utils.IntegrityError: could not create unique index "logger_submissioncounter_user_id_timestamp_e6900e6e_uniq"
DETAIL:  Key (user_id, "timestamp")=(335741, 2021-08-02) is duplicated.
```