### PR TITLE
Allow `model` to be used as a field name

### DIFF
--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -78,15 +78,10 @@ class DataDictionary(XForm):
         doc = clean_and_parse_xml(self.xml)
         model_nodes = doc.getElementsByTagName("model")
         if len(model_nodes) != 1:
-            node_counts = 0
             for node in model_nodes:
-                if hasattr(node, 'firstChild') and hasattr(node.firstChild, 'nodeName'):
-                    if node.firstChild.nodeName == 'instance':
-                        if node_counts != 0:
-                            raise Exception("xml contains multiple model nodes")
-                        else:
-                            model_node = node
-                            node_counts += 1
+                if hasattr(node, 'parentNode') and node.parentNode.tagName == 'h:head':
+                    model_node = node
+                    break
         else:
             model_node = model_nodes[0]
         instance_nodes = [node for node in model_node.childNodes if

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -78,9 +78,17 @@ class DataDictionary(XForm):
         doc = clean_and_parse_xml(self.xml)
         model_nodes = doc.getElementsByTagName("model")
         if len(model_nodes) != 1:
-            raise Exception("xml contains multiple model nodes")
-
-        model_node = model_nodes[0]
+            node_counts = 0
+            for node in model_nodes:
+                if hasattr(node, 'firstChild') and hasattr(node.firstChild, 'nodeName'):
+                    if node.firstChild.nodeName == 'instance':
+                        if node_counts != 0:
+                            raise Exception("xml contains multiple model nodes")
+                        else:
+                            model_node = node
+                            node_counts += 1
+        else:
+            model_node = model_nodes[0]
         instance_nodes = [node for node in model_node.childNodes if
                           node.nodeType == Node.ELEMENT_NODE and
                           node.tagName.lower() == "instance" and


### PR DESCRIPTION
## Description

Allow `model` to be used as a field name in a form.

## Related
closes #486 