### PR TITLE
Match KPI GitHub Actions pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,14 +38,19 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Upgrade pip
-      run: python -m pip install pip==22.0.4
+    - name: Install pip-tools
+      run: python -m pip install pip-tools==6.\*
     - name: Update apt package lists
       run: sudo apt update
-    - name: Install apt dependencies
-      run: sudo apt-get install ghostscript libxml2-dev libxslt-dev python3-dev gdal-bin libproj-dev gettext postgresql-client openjdk-11-jre
+    - name: Update Debian package lists
+      run: sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
+    - name: Install Debian dependencies
+      run: >-
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install 
+        ghostscript libxml2-dev libxslt-dev python3-dev gdal-bin libproj-dev 
+        gettext postgresql-client openjdk-11-jre build-essential
     - name: Install Python dependencies
-      run: pip install -r dependencies/pip/dev_requirements.txt
+      run: pip-sync dependencies/pip/dev_requirements.txt
     - name: Run pytest
       run: pytest -vv -rf
       env:

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -345,7 +345,7 @@ urllib3==1.26.9
     #   botocore
     #   requests
     #   sentry-sdk
-uwsgi==2.0.20
+uwsgi==2.0.21
     # via -r dependencies/pip/requirements.in
 vine==5.0.0
     # via

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -266,7 +266,7 @@ urllib3==1.26.9
     #   botocore
     #   requests
     #   sentry-sdk
-uwsgi==2.0.20
+uwsgi==2.0.21
     # via -r dependencies/pip/requirements.in
 vine==5.0.0
     # via


### PR DESCRIPTION
# Description 
Use `pip-sync` (like in KPI) instead of `pip` directly and bump uWSGI version to 2.0.21

# Related issues

kobotoolbox/kpi#4265