### PR TITLE
Fix exports being blocked by CSP…

### DIFF
--- a/onadata/apps/viewer/static/js/export_list.js
+++ b/onadata/apps/viewer/static/js/export_list.js
@@ -67,7 +67,7 @@ var fhExportList =  (function(){
                                 if(status.url)
                                 {
                                     parent.empty()
-                                    parent.append($('<a></a>').attr('href', status.url).html(status.filename))
+                                    parent.append($('<a></a>').attr('href', status.url).attr('target', '_blank').html(status.filename))
                                 }
                                 else
                                 {


### PR DESCRIPTION
due to omission in #867, where clicking "New Export" and remaining on the export page without refreshing caused the "Pending ..." message to be transformed by JS into a link that lacked the `target="_blank"` attribute