### PR TITLE
Replace deprecated constants in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ build:
   services:
     - docker:dind
   before_script:
-    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.gitlab.com
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} || true
     - docker build --cache-from $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} .


### PR DESCRIPTION
Gitlab has [deprecated](https://docs.gitlab.com/ee/update/deprecations.html#ci_build_-predefined-variables) `$CI_BUILD_TOKEN` in favor of `$CI_JOB_TOKEN`, which broke the `build` step of the GitLab actions. This PR updates that constant.

See https://github.com/kobotoolbox/kpi/pull/4433 for a prior PR that fixed this for kpi.
