### PR TITLE
Upgrade OpenJDK for Debian 12

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ test:
     - name: redis:6.2
       alias: redis_cache
   script:
-    - apt-get update && apt-get install -y ghostscript gdal-bin libproj-dev gettext openjdk-11-jre
+    - apt-get update && apt-get install -y ghostscript gdal-bin libproj-dev gettext openjdk-17-jre
     - pip install -r dependencies/pip/dev_requirements.txt
     - pytest -vv -rf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get -qq update && \
         libproj-dev \
         libsqlite3-mod-spatialite \
         locales \
-        openjdk-11-jre \
+        openjdk-17-jre \
         postgresql-client \
         procps \
         rsync \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN mkdir -p ${NGINX_STATIC_DIR} && \
 # jnm (or the current on-call sysadmin). Thanks.
 
 RUN apt-get -qq update && \
+    apt-get -qq -y install openjdk-17-jre && \
     apt-get -qq -y install \
         cron \
         gdal-bin \
@@ -62,7 +63,6 @@ RUN apt-get -qq update && \
         libproj-dev \
         libsqlite3-mod-spatialite \
         locales \
-        openjdk-17-jre \
         postgresql-client \
         procps \
         rsync \


### PR DESCRIPTION
python:3.10 base image now includes openjdk-17-jre; version 11 is removed