### PR TITLE
Purge non-dict UserProfile.metadata when calculating submission counters

### DIFF
--- a/onadata/apps/logger/management/commands/populate_submission_counters.py
+++ b/onadata/apps/logger/management/commands/populate_submission_counters.py
@@ -201,7 +201,7 @@ class Command(BaseCommand):
         ) = UserProfile.objects.get_or_create(user_id=user.pk)
 
         # Some old profiles don't have metadata
-        if user_profile.metadata is None:
+        if user_profile.metadata is None or not isinstance(user_profile.metadata, dict):
             user_profile.metadata = {}
 
         # Set the flag `submissions_suspended` to true if it is not already.


### PR DESCRIPTION
Fixes crash seen when attempting to migrate kc.unu:
```
Traceback (most recent call last):
  File "/srv/src/kobocat/./manage.py", line 17, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/commands/migrate.py", line 244, in handle
    post_migrate_state = executor.migrate(
  File "/opt/venv/lib/python3.10/site-packages/django/db/migrations/executor.py", line 117, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/opt/venv/lib/python3.10/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/opt/venv/lib/python3.10/site-packages/django/db/migrations/executor.py", line 227, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/opt/venv/lib/python3.10/site-packages/django/db/migrations/migration.py", line 126, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/opt/venv/lib/python3.10/site-packages/django/db/migrations/operations/special.py", line 190, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/srv/src/kobocat/onadata/apps/logger/migrations/0028_populate_daily_xform_counters_for_year.py", line 28, in populate_daily_counts_for_year
    call_command('populate_submission_counters', force=True, skip_monthly=True)
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 181, in call_command
    return command.execute(*args, **defaults)
  File "/opt/venv/lib/python3.10/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/srv/src/kobocat/onadata/apps/logger/management/commands/populate_submission_counters.py", line 94, in handle
    self.suspend_submissions_for_user(user)
  File "/srv/src/kobocat/onadata/apps/logger/management/commands/populate_submission_counters.py", line 208, in suspend_submissions_for_user
    if not user_profile.metadata.get('submissions_suspended'):
AttributeError: 'list' object has no attribute 'get'
```
