### PR TITLE
Update populate_xform_submission migration dependencies

### DIFF
--- a/onadata/apps/logger/migrations/0028_populate_daily_xform_counters_for_year.py
+++ b/onadata/apps/logger/migrations/0028_populate_daily_xform_counters_for_year.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('logger', '0027_on_delete_cascade_monthlyxformsubmissioncounter'),
-        ('main', '0010_userprofile_metadata_jsonfield'),
+        ('main', '0012_add_validate_password_flag_to_profile'),
     ]
 
     # We don't do anything when migrating in reverse


### PR DESCRIPTION
## Description

Applying `logger.0028` before `main.0012` (from #885) raises an error (`column main_userprofile.validated_password does not exist`). This PR updates the dependency list for `logger.0028` accordingly.