### PR TITLE
Prevent SKIP_HEAVY_MIGRATIONS warning unless running the relevant migrations

### DIFF
--- a/onadata/apps/main/migrations/0011_drop_old_kpi_tables.py
+++ b/onadata/apps/main/migrations/0011_drop_old_kpi_tables.py
@@ -58,13 +58,6 @@ def get_operations():
         return []
 
     tables = DEPRECATED_TABLES + KPI_TABLES
-    print(
-        """
-        This migration might take a while. If it is too slow, you may want to 
-        re-run migrations with SKIP_HEAVY_MIGRATIONS=True and apply this one 
-        manually from the django shell.
-        """
-    )
     operations = []
 
     sql = """
@@ -105,10 +98,22 @@ def get_operations():
     return operations
 
 
+def print_migration_warning(apps, schema_editor):
+    if settings.TESTING_MODE or settings.SKIP_HEAVY_MIGRATIONS:
+        return
+    print(
+        """
+        This migration might take a while. If it is too slow, you may want to 
+        re-run migrations with SKIP_HEAVY_MIGRATIONS=True and apply this one 
+        manually from the django shell.
+        """
+    )
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
         ('main', '0010_userprofile_metadata_jsonfield'),
     ]
 
-    operations = get_operations()
+    operations = [migrations.RunPython(print_migration_warning), *get_operations()]


### PR DESCRIPTION
## Description

Refactors `main.0011_drop_old_kpi_tables` to not print a heavy migration warning every time Django loads the migration file (e.g. when running `./manage.py migrate` for an unrelated app).