### PR TITLE
Improve `update_attachment_storage_bytes` management command

### DIFF
--- a/onadata/apps/logger/management/commands/update_attachment_storage_bytes.py
+++ b/onadata/apps/logger/management/commands/update_attachment_storage_bytes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand
-from django.db.models import Sum, Q, OuterRef, Subquery
+from django.db.models import Sum, OuterRef, Subquery
 
 from onadata.apps.logger.models.attachment import Attachment
 from onadata.apps.logger.models.xform import XForm
@@ -63,6 +63,16 @@ class Command(BaseCommand):
                 '`force` and `sync` options cannot be used together'
             )
             return
+
+        if self._sync and self._verbosity >= 1:
+            self.stdout.write(
+                '`sync` option has been enabled'
+            )
+
+        if self._force and self._verbosity >= 1:
+            self.stdout.write(
+                '`force` option has been enabled'
+            )
 
         if not skip_lock_release:
             self._release_locks()

--- a/onadata/apps/logger/management/commands/update_attachment_storage_bytes.py
+++ b/onadata/apps/logger/management/commands/update_attachment_storage_bytes.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict
-
 from django.core.management.base import BaseCommand
 from django.db.models import Sum, Q, OuterRef, Subquery
 
@@ -17,38 +15,71 @@ class Command(BaseCommand):
         'per xform and user profile'
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._verbosity = 0
+        self._force = False
+        self._sync = False
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--chunks',
+            type=int,
+            default=2000,
+            help="Number of records to process per query"
+        )
+
+        parser.add_argument(
+            '-f', '--force',
+            action='store_true',
+            default=False,
+            help='Recalculate counters for every user. Default is False',
+        )
+
+        parser.add_argument(
+            '-s', '--sync',
+            action='store_true',
+            default=False,
+            help='Update only out of sync counters. Default is False',
+        )
+
+        parser.add_argument(
+            '-l', '--skip-lock-release',
+            action='store_true',
+            default=False,
+            help='Do not attempts to remove submission lock on user profiles. Default is False',
+        )
+
     def handle(self, *args, **kwargs):
-        self.verbosity = kwargs['verbosity']
 
-        # Release any locks on the users' profile from getting submissions
-        UserProfile.objects.all().update(
-            metadata=ReplaceValues(
-                'metadata',
-                updates={'submissions_suspended': False},
-            ),
-        )
+        self._verbosity = kwargs['verbosity']
+        self._force = kwargs['force']
+        self._sync = kwargs['sync']
+        chunks = kwargs['chunks']
+        skip_lock_release = kwargs['skip_lock_release']
 
-        # Get all profiles already updated to exclude their forms from the list.
-        # It is a lazy query and will be `xforms` queryset.
-        subquery = UserProfile.objects.values_list('user_id', flat=True).filter(
-            metadata__attachments_counting_status='complete'
-        )
-        # Get only xforms whose users' storage counters have not been updated yet
-        xforms = (
-            XForm.objects.exclude(user_id__in=subquery)
-            .values('pk', 'user_id', 'user__username')
-            .order_by('user_id')
-        )
+        if self._force and self._sync:
+            self.stderr.write(
+                '`force` and `sync` options cannot be used together'
+            )
+            return
+
+        if not skip_lock_release:
+            self._release_locks()
+
+        profile_queryset = self._reset_user_profile_counters()
+
+        xform_queryset = self._get_queryset(profile_queryset)
 
         last_xform = None
 
-        for xform in xforms:
+        for xform in xform_queryset.iterator(chunk_size=chunks):
 
             if not last_xform or (last_xform['user_id'] != xform['user_id']):
 
                 # All forms for the previous user are complete; update that user's profile
                 if last_xform:
-                    self.update_user_profile(last_xform)
+                    self._update_user_profile(last_xform)
 
                 # Retrieve or create user's profile.
                 (
@@ -69,7 +100,7 @@ class Command(BaseCommand):
                     user_profile.save(update_fields=['metadata'])
 
             # write out xform progress
-            if self.verbosity >= 1:
+            if self._verbosity > 1:
                 self.stdout.write(
                     f"Calculating attachments for xform_id #{xform['pk']}"
                     f" (user {xform['user__username']})"
@@ -80,36 +111,96 @@ class Command(BaseCommand):
             ).aggregate(total=Sum('media_file_size'))
 
             if form_attachments['total']:
-                if self.verbosity >= 1:
+                if self._verbosity > 2:
                     self.stdout.write(
                         f'\tUpdating xform attachment storage to '
                         f"{form_attachments['total']} bytes"
                     )
 
-                XForm.objects.filter(
+                XForm.all_objects.filter(
                     pk=xform['pk']
                 ).update(
                     attachment_storage_bytes=form_attachments['total']
                 )
 
-            elif self.verbosity >= 1:
+            elif self._verbosity > 2:
                 self.stdout.write('\tNo attachments found')
+                XForm.all_objects.filter(
+                    pk=xform['pk']
+                ).update(
+                    attachment_storage_bytes=0
+                )
 
             last_xform = xform
 
         # need to call `update_user_profile()` one more time outside the loop
         # because the last user profile will not be up-to-date otherwise
         if last_xform:
-            self.update_user_profile(last_xform)
+            self._update_user_profile(last_xform)
 
-        if self.verbosity >= 1:
+        if self._verbosity >= 1:
             self.stdout.write('Done!')
 
-    def update_user_profile(self, xform: dict):
+    def _get_queryset(self, profile_queryset):
+        # Get all profiles already updated to exclude their forms from the list.
+        # It is a lazy query and will be `xforms` queryset.
+        xforms = XForm.all_objects
+        if not self._force and not self._sync:
+            subquery = UserProfile.objects.values_list('user_id', flat=True).filter(
+                metadata__attachments_counting_status='complete'
+            )
+            xforms = xforms.exclude(user_id__in=subquery)
+
+        if self._sync:
+            subquery = list(profile_queryset.values_list('user_id', flat=True))
+            xforms = xforms.filter(user_id__in=subquery)
+
+        # Get only xforms whose users' storage counters have not been updated yet
+        xforms = xforms.values('pk', 'user_id', 'user__username').order_by(
+            'user_id'
+        )
+        return xforms
+
+    def _release_locks(self):
+        # Release any locks on the users' profile from getting submissions
+        if self._verbosity > 1:
+            self.stdout.write('Releasing submission locks…')
+
+        UserProfile.objects.all().update(
+            metadata=ReplaceValues(
+                'metadata',
+                updates={'submissions_suspended': False},
+            ),
+        )
+
+    def _reset_user_profile_counters(self):
+
+        # Update all user profile storage counters to zero that do not match
+        # sum of all related xform storage counters.
+        if self._verbosity > 1:
+            self.stdout.write('Resetting user profile storage counters…')
+
+        subquery = Subquery(
+            XForm.all_objects.filter(user_id=OuterRef('user_id'))
+            .values('user_id')
+            .annotate(total=Sum('attachment_storage_bytes'))
+            .values('total')
+        )
+
+        profile_query = UserProfile.objects.exclude(
+            attachment_storage_bytes=Subquery(subquery)
+        )
+        update = profile_query.update(attachment_storage_bytes=0)
+        if self._verbosity > 1:
+            self.stdout.write(f'Updated user profile storage counters: {update}')
+
+        return profile_query
+
+    def _update_user_profile(self, xform: dict):
         user_id = xform['user_id']
         username = xform['user__username']
 
-        if self.verbosity >= 1:
+        if self._verbosity >= 1:
             self.stdout.write(
                 f'Updating attachment storage total on '
                 f'{username}’s profile'
@@ -125,7 +216,7 @@ class Command(BaseCommand):
         # right away. See https://stackoverflow.com/a/56122354/1141214 for
         # details.
         subquery = (
-            XForm.objects.filter(user_id=user_id)
+            XForm.all_objects.filter(user_id=user_id)
             .values('user_id')
             .annotate(total=Sum('attachment_storage_bytes'))
             .values('total')

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -117,3 +117,8 @@ def generate_stats_zip(output_filename):
             csv_io.close()
 
         zip_file.close()
+
+
+@app.task()
+def sync_storage_counters():
+    call_command('update_attachment_storage_bytes', verbosity=3, sync=True)


### PR DESCRIPTION
## Description 

Return a more accurate global storage metric when user has no projects

## Additional info 
Add three new options to management command: 

- `force` to recalculate counters for every user - even those already calculated
- `sync` to recalculate all the counters of users whose profile does not correspond with the projects
- `skip-lock-release` to avoid release submission locks (useful (and faster) when all locks are already released)