### PR TITLE
Improve `soft_delete_orphan_attachments` management command speed

### DIFF
--- a/onadata/apps/logger/management/commands/soft_delete_orphan_attachments.py
+++ b/onadata/apps/logger/management/commands/soft_delete_orphan_attachments.py
@@ -11,7 +11,6 @@ from onadata.apps.logger.models import (
 )
 from onadata.apps.logger.signals import pre_delete_attachment
 from onadata.libs.utils.logger_tools import get_soft_deleted_attachments
-from onadata.apps.viewer.models.parsed_instance import datetime_from_str
 
 
 class Command(BaseCommand):
@@ -62,7 +61,9 @@ class Command(BaseCommand):
             'to run on big databases'
         )
 
-        instance_ids = Attachment.objects.values_list('instance_id', flat=True).distinct()
+        instance_ids = Attachment.objects.values_list(
+            'instance_id', flat=True
+        ).distinct()
 
         if start_id:
             instance_ids = instance_ids.filter(instance_id__gte=start_id)
@@ -112,6 +113,8 @@ class Command(BaseCommand):
                 continue
 
             for soft_deleted_attachment in soft_deleted_attachments:
+                # Avoid fetching Instance object once again
+                soft_deleted_attachment.instance = instance
                 pre_delete_attachment(
                     soft_deleted_attachment, only_update_counters=True
                 )

--- a/onadata/apps/logger/management/commands/soft_delete_orphan_attachments.py
+++ b/onadata/apps/logger/management/commands/soft_delete_orphan_attachments.py
@@ -8,6 +8,7 @@ from onadata.apps.logger.models import (
 )
 from onadata.apps.logger.signals import pre_delete_attachment
 from onadata.libs.utils.logger_tools import get_soft_deleted_attachments
+from onadata.apps.viewer.models.parsed_instance import datetime_from_str
 
 
 class Command(BaseCommand):
@@ -19,14 +20,33 @@ class Command(BaseCommand):
             '--chunks',
             type=int,
             default=2000,
-            help="Number of records to process per query"
+            help='Number of records to process per query'
+        )
+
+        parser.add_argument(
+            '--start-id',
+            type=int,
+            default=0,
+            help='Instance ID to start from'
+        )
+
+        parser.add_argument(
+            '--start-date',
+            type=str,
+            default=None,
+            help='Starting date to start from. Format: yyyy-mm-aa.'
         )
 
     def handle(self, *args, **kwargs):
         chunks = kwargs['chunks']
         verbosity = kwargs['verbosity']
+        start_id = kwargs['start_id']
+        start_date = kwargs['start_date']
 
         queryset = Attachment.objects.values_list('instance_id', flat=True).distinct()
+
+        if start_id:
+            queryset = queryset.filter(instance_id__gte=start_id)
 
         if verbosity > 1:
             self.stdout.write(
@@ -43,11 +63,58 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f'Processing Instance object #{instance_id}{message}…'
                 )
-            soft_deleted_attachments = get_soft_deleted_attachments(instance)
+
+            if start_date and instance.date_created < datetime_from_str(
+                f'{start_date}T00:00:00 +0000'
+            ):
+                if verbosity > 1:
+                    message = '' if verbosity <= 1 else f' - {cpt}/{instances_count}'
+                    self.stdout.write(
+                        f'\tSkip Instance object #{instance_id}{message}. Too old'
+                    )
+                cpt += 1
+                continue
+
+            if not self._has_instance_been_edited(instance):
+                if verbosity > 1:
+                    message = '' if verbosity <= 1 else f' - {cpt}/{instances_count}'
+                    self.stdout.write(
+                        f'\tSkip Instance object #{instance_id}{message}. Not edited'
+                    )
+                cpt += 1
+                continue
+
+            try:
+                soft_deleted_attachments = get_soft_deleted_attachments(instance)
+            except Exception as e:
+                cpt += 1
+                if verbosity > 0:
+                    self.stderr.write(
+                        f'\tError for Instance object #{instance_id}: {str(e)}'
+                    )
+                continue
+
             for soft_deleted_attachment in soft_deleted_attachments:
                 pre_delete_attachment(
                     soft_deleted_attachment, only_update_counters=True
                 )
+            if verbosity > 1:
+                message = '' if verbosity <= 1 else f' - {cpt}/{instances_count}'
+                self.stdout.write(
+                    f'\tInstance object #{instance_id}{message} updated!'
+                )
+            cpt += 1
 
             cpt += 1
         self.stdout.write('Done!')
+
+    def _has_instance_been_edited(self, instance):
+        """
+        Consider instance as edited if it modification date is more or less 10
+        seconds apart
+        """
+        date_created_ts = instance.date_created.timestamp()
+        date_modified_ts = instance.date_modified.timestamp()
+        return not (
+            date_created_ts <= date_modified_ts <= date_created_ts + 10
+        )

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -252,7 +252,7 @@ class Instance(models.Model):
                               default='submitted_via_web')
     uuid = models.CharField(max_length=249, default='', db_index=True)
 
-    # store an geographic objects associated with this instance
+    # store a geographic objects associated with this instance
     geom = models.GeometryCollectionField(null=True)
 
     tags = TaggableManager()

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+from copy import deepcopy
 from io import BytesIO
 from xml.sax.saxutils import escape as xml_escape
 
@@ -129,10 +130,15 @@ class XForm(BaseModel):
             }
         )
 
-    def data_dictionary(self):
-        from onadata.apps.viewer.models.data_dictionary import\
-            DataDictionary
-        return DataDictionary.all_objects.get(pk=self.pk)
+    def data_dictionary(self, use_cache: bool = False):
+        from onadata.apps.viewer.models.data_dictionary import DataDictionary
+
+        if not use_cache:
+            return DataDictionary.all_objects.get(pk=self.pk)
+
+        xform_dict = deepcopy(self.__dict__)
+        xform_dict.pop('_state', None)
+        return DataDictionary(**xform_dict)
 
     @property
     def has_instances_with_geopoints(self):

--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -366,10 +366,9 @@ def get_xform_media_question_xpaths(
     xform: 'onadata.apps.logger.models.XForm',
 ) -> list:
     logger = logging.getLogger('console_logger')
-    parser = XFormInstanceParser(xform.xml, xform.data_dictionary())
+    parser = XFormInstanceParser(xform.xml, xform.data_dictionary(use_cache=True))
     all_attributes = _get_all_attributes(parser.get_root_node())
     media_field_xpaths = []
-
     # This code expects that the attributes from Enketo Express are **always**
     # sent in the same order.
     # For example:


### PR DESCRIPTION
## Description

Only process edited submissions

## Notes

Each submission has two dates, `date_created` and `date_modified`. After some testing, it appeared that `date_modified` is the (almost) same (within a few milliseconds)  than `date_created` when the submission is not edited. 
Assuming that its almost impossible to edit a submission within 10 seconds of the creation, the management command now skips submissions where its modification date is more or less 10 seconds of the creation.
