### PR TITLE
Fix 500 error when fetching data with a date range

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -824,3 +824,18 @@ class TestDataViewSet(TestBase):
         view = DataViewSet.as_view({'get': 'list'})
         response = view(request, pk=self.xform.pk)
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_list_data_with_custom_handler(self):
+        request = self.factory.get('/', **self.extra)
+        view = DataViewSet.as_view({'get': 'list'})
+        response = view(request, pk=self.xform.pk, format='xlsx')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers['Content-Type'] == 'application/vnd.openxmlformats'
+
+    def test_list_data_with_custom_handler_and_date_range(self):
+        qs_params = '?start=21_10_17_00_00_00&end=23_12_01_00_00_00'
+        request = self.factory.get(f'/{qs_params}', **self.extra)
+        view = DataViewSet.as_view({'get': 'list'})
+        response = view(request, pk=self.xform.pk, format='xlsx')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers['Content-Type'] == 'application/vnd.openxmlformats'

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -82,11 +82,13 @@ def _set_start_end_params(request, query):
         try:
             if request.GET.get('start'):
                 query[SUBMISSION_TIME]['$gte'] = format_date_for_mongo(
-                    request.GET['start'], datetime)
+                    request.GET['start']
+                )
 
             if request.GET.get('end'):
                 query[SUBMISSION_TIME]['$lte'] = format_date_for_mongo(
-                    request.GET['end'], datetime)
+                    request.GET['end']
+                )
         except ValueError:
             raise exceptions.ParseError(
                 t("Dates must be in the format YY_MM_DD_hh_mm_ss")


### PR DESCRIPTION
## Description
⚠️  `/api/v1/data/<pk>.<format>` is **deprecated** and `/api/v2/` should be used instead.

## Additional info 
For xls(x) and csv formats, please read [this article](https://support.kobotoolbox.org/synchronous_exports.html) and also the [thread in community forum](https://community.kobotoolbox.org/t/how-to-download-data-between-two-dates-from-date-to-date/25569/4) mentioned at the end of the article to use`/api/v2`.