### PR TITLE
Fix missing encrypted files when exporting or viewing submitted data 

### DIFF
--- a/onadata/apps/logger/management/commands/soft_delete_orphan_attachments_2_023_37c_fix.py
+++ b/onadata/apps/logger/management/commands/soft_delete_orphan_attachments_2_023_37c_fix.py
@@ -46,6 +46,7 @@ class Command(BaseCommand):
 
         queryset = Attachment.all_objects.filter(
             Q(media_file_basename='audit.csv')
+            | Q(media_file_basename__endswith='.enc')
             | Q(media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$'),
             deleted_at__isnull=False,
         )
@@ -58,6 +59,7 @@ class Command(BaseCommand):
 
         att_queryset = Attachment.all_objects.filter(
             Q(media_file_basename='audit.csv')
+            | Q(media_file_basename__endswith='.enc')
             | Q(media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$')
         )
         if not force:
@@ -82,6 +84,7 @@ class Command(BaseCommand):
                 )
             Attachment.all_objects.filter(
                 Q(media_file_basename='audit.csv')
+                | Q(media_file_basename__endswith='.enc')
                 | Q(media_file_basename__regex=r'^\d+\.(m4a|amr)$'),
                 instance_id=instance.pk,
             ).update(deleted_at=None)

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -738,6 +738,7 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
     #  Bug comes from `get_xform_media_question_xpaths()`
     queryset = Attachment.objects.filter(instance=instance).exclude(
         Q(media_file_basename__in=basenames)
+        | Q(media_file_basename__endswith='.enc')
         | Q(media_file_basename='audit.csv')
         | Q(media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$')
     )


### PR DESCRIPTION
## Description

Run `python3 manage.py soft_delete_orphan_attachments_2_023_37c_fix` (again) inside the KoboCAT container to fix existing submissions.


## Notes

See #905.