### PR TITLE
Fix Enketo error `Unable to auto-detect delimiting character; defaulted to ','`

### DIFF
--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -18,7 +18,7 @@ from django.http import (
     HttpResponseRedirect,
 )
 from django.utils.translation import gettext as t
-from kobo_service_account.utils import get_real_user
+from kobo_service_account.utils import get_real_user, get_request_headers
 from rest_framework import exceptions
 from rest_framework.authtoken.models import Token
 from rest_framework.request import Request
@@ -31,8 +31,6 @@ from onadata.apps.viewer.models.parsed_instance import datetime_from_str
 from onadata.libs.utils.logger_tools import (
     publish_form,
     response_with_mimetype_and_name,
-    OPEN_ROSA_VERSION_HEADER,
-    OPEN_ROSA_VERSION,
 )
 from onadata.libs.utils.user_auth import (
     check_and_set_form_by_id,
@@ -213,12 +211,12 @@ def get_media_file_response(
     # an HTTP redirection. We use KoBoCAT to proxy the response from KPI
     headers = {}
     if not request.user.is_anonymous:
-        token = Token.objects.get(user=request.user)
-        headers['Authorization'] = f'Token {token.key}'
+        headers = get_request_headers(request.user.username)
 
     # Send the request internally to avoid extra traffic on the public interface
-    internal_url = metadata.data_value.replace(settings.KOBOFORM_URL,
-                                               settings.KOBOFORM_INTERNAL_URL)
+    internal_url = metadata.data_value.replace(
+        settings.KOBOFORM_URL, settings.KOBOFORM_INTERNAL_URL
+    )
     response = requests.get(internal_url, headers=headers)
 
     return HttpResponse(

--- a/onadata/apps/api/viewsets/metadata_viewset.py
+++ b/onadata/apps/api/viewsets/metadata_viewset.py
@@ -170,10 +170,11 @@ Accept: image/png </pre>
     def retrieve(self, request, *args, **kwargs):
         self.object = self.get_object()
 
-        if isinstance(request.accepted_renderer, MediaFileRenderer) \
-                and self.object.data_file is not None:
-
-            return get_media_file_response(self.object)
+        if (
+            isinstance(request.accepted_renderer, MediaFileRenderer)
+            and self.object.data_file is not None
+        ):
+            return get_media_file_response(self.object, request)
 
         serializer = self.get_serializer(self.object)
 


### PR DESCRIPTION
## Description 
Use Service Account to authenticate requests between Kobocat and KPI instead of user's token.

## Related issues

Closes #908 
Blocked by kobotoolbox/kpi#4741
