### PR TITLE
Pin docker/dind to 24.0.6 to fix CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,8 @@ include:
 
 build:
   stage: build_test
+  # Please un-pin the version (24.0.6) once the following GitLab issue is resolved:
+  # https://gitlab.com/gitlab-com/gl-infra/production/-/issues/17283
   image: docker:24.0.6
   services:
     - docker:24.0.6-dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,9 @@ include:
 
 build:
   stage: build_test
-  image: docker
+  image: docker:24.0.6
   services:
-    - docker:dind
+    - docker:24.0.6-dind
   before_script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes an issue with Docker images that cause GitLab CI to fail on the 'build' step.

## Notes

Same fix for docker image as we made [here](https://github.com/kobotoolbox/kpi/pull/4768) for KPI.