### PR TITLE
Remove sites framework

### DIFF
--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -10,7 +10,6 @@ import rest_framework.views as rest_framework_views
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.sites.models import Site
 from django.core.files.storage import default_storage
 from django.http import (
     HttpResponse,
@@ -245,7 +244,7 @@ def get_view_description(view_obj, html=False):
     Replace example.com in Django REST framework's default API description
     with the domain name of the current site
     """
-    domain = Site.objects.get_current().domain
+    domain = settings.KOBOCAT_PUBLIC_HOSTNAME
     description = rest_framework_views.get_view_description(view_obj, html)
     # description might not be a plain string: e.g. it could be a SafeText
     # to prevent further HTML escaping

--- a/onadata/apps/main/context_processors.py
+++ b/onadata/apps/main/context_processors.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 from django.conf import settings
-from django.contrib.sites.models import Site
 
 
 def google_analytics(request):
@@ -15,14 +14,7 @@ def google_analytics(request):
 
 
 def site_name(request):
-    site_id = getattr(settings, 'SITE_ID', None)
-    try:
-        site = Site.objects.get(pk=site_id)
-    except Site.DoesNotExist:
-        site_name = 'example.org'
-    else:
-        site_name = site.name
-    return {'SITE_NAME': site_name}
+    return {'SITE_NAME': settings.KOBOCAT_PUBLIC_HOSTNAME}
 
 
 def base_url(request):

--- a/onadata/apps/main/tests/test_custom_context_processors.py
+++ b/onadata/apps/main/tests/test_custom_context_processors.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-from django.conf import settings
 from django.test import TestCase
 from onadata.apps.main.context_processors import site_name
 
@@ -7,9 +6,4 @@ from onadata.apps.main.context_processors import site_name
 class CustomContextProcessorsTest(TestCase):
     def test_site_name(self):
         context = site_name(None)
-        self.assertEqual(context, {'SITE_NAME': 'example.com'})
-        restore_site_id = settings.SITE_ID
-        settings.SITE_ID = 100
-        context = site_name(None)
-        self.assertEqual(context, {'SITE_NAME': 'example.org'})
-        settings.SITE_ID = restore_site_id
+        self.assertEqual(context, {'SITE_NAME': 'kc.kobotoolbox.org'})

--- a/onadata/apps/main/tests/test_custom_context_processors.py
+++ b/onadata/apps/main/tests/test_custom_context_processors.py
@@ -1,9 +1,10 @@
 # coding: utf-8
-from django.test import TestCase
+from django.test import override_settings, TestCase
 from onadata.apps.main.context_processors import site_name
 
 
 class CustomContextProcessorsTest(TestCase):
+    @override_settings(KOBOCAT_PUBLIC_HOSTNAME="kc.kobotoolbox.org")
     def test_site_name(self):
         context = site_name(None)
         self.assertEqual(context, {'SITE_NAME': 'kc.kobotoolbox.org'})

--- a/onadata/libs/utils/user_auth.py
+++ b/onadata/libs/utils/user_auth.py
@@ -2,9 +2,9 @@
 import re
 from functools import wraps
 
+from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
-from django.contrib.sites.models import Site
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404
 from guardian.shortcuts import get_perms_for_model, assign_perm
@@ -25,7 +25,7 @@ class HttpResponseNotAuthorized(HttpResponse):
     def __init__(self):
         HttpResponse.__init__(self)
         self['WWW-Authenticate'] =\
-            'Basic realm="%s"' % Site.objects.get_current().name
+            'Basic realm="%s"' % settings.KOBOCAT_PUBLIC_HOSTNAME
 
 
 def check_and_set_user(request, username):

--- a/onadata/settings/base.py
+++ b/onadata/settings/base.py
@@ -67,8 +67,6 @@ USE_TZ = True
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
-SITE_ID = env.int('DJANGO_SITE_ID', 1)
-
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
 USE_I18N = True
@@ -192,7 +190,6 @@ INSTALLED_APPS = [
     # https://code.djangoproject.com/ticket/10827
     'django.contrib.auth',
     'django.contrib.sessions',
-    'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',


### PR DESCRIPTION
Remove Django sites framework, which duplicates functionality of existing django settings.

Resolves TASK-424

# Notes

- [x] Review user_auth.py change

For reference, the default is:

```
In [6]: site.name
Out[6]: 'example.com'
In [7]: site.domain
Out[7]: 'example.com'
In [10]: settings.KOBOCAT_PUBLIC_HOSTNAME
Out[10]: 'kc.kobotoolbox.org'
```