### PR TITLE
add job to deploy kobocat to staging if branch starts with 'feature/'

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,3 +61,15 @@ deploy-beta:
       - gitlab-ci-build
     variables:
       - $CI_COMMIT_REF_PROTECTED
+
+deploy-staging:
+  stage: deploy
+  image:
+    name: alpine/helm
+    entrypoint: [""]
+  script:
+    - BRANCH_TITLE=${CI_COMMIT_BRANCH#feature/}
+    - helm repo add kobo https://gitlab.com/api/v4/projects/32216873/packages/helm/stable
+    - helm -n kobo-dev upgrade --install $BRANCH_TITLE kobo/kobo --atomic --set-string kobocat.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^(feature\/)/ && $CI_COMMIT_REF_PROTECTED


### PR DESCRIPTION
This PR adds a job to automatically deploy Kobocat branches that start with `feature/` to k8s. It's pretty much a straight port of the job with the same name (`deploy-staging`) from kpi's `.gitlab-ci.yml`.

You can see a sample run [here](https://gitlab.com/kobo_toolbox/kobocat/-/jobs/6032640880) using `feature/tri` - the failed runs can safely be ignored, I just needed to protect `feature*` branches in GitLab. That code triggered a deployment to https://kf.tri.kbtdev.org/ , which I've verified as successful.